### PR TITLE
セッション管理機構＋各種インフラ構築

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*node_modules/

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,6 +11,7 @@ phases:
       - npm install
       - cd ../neo-cycle-lambda
       - cd ./SessionMaintainer
+      - npm install
       - zip -r Deploy.zip ./
       - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
       - cd ../../neo-cycle-infra

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,7 +17,7 @@ phases:
       - cd ../../neo-cycle-infra
       - aws cloudformation deploy
           --stack-name neo-cycle-lambda
-          --template-file /Lambda/lambda.yaml
+          --template-file file://Lambda/lambda.yaml
           --parameter-overrides ObjectKeyPrefix=${CODEBUILD_BUILD_NUMBER}
           --capabilities CAPABILITY_AUTO_EXPAND
       - cd ..

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,7 +17,7 @@ phases:
       - aws cloudformation create-stack
           --stack-name neo-cycle-lambda
           --template-body file://Lambda/lambda.yaml
-          --parameters ParameterKey=BucketKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER}
+          --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER}
           --capabilities CAPABILITY_AUTO_EXPAND
       - aws cloudformation wait stack-create-complete
         --stack-name presto-lambda-${ENV_NAME}

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,10 +15,11 @@ phases:
       - zip -r Deploy.zip ./
       - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
       - cd ../../neo-cycle-infra
-      - res=$(aws cloudformation describe-stacks --stack-name neo-cycle-lambda)
-      - if [[ $res =~ COMPLETE ]] ; then aws cloudformation update-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-update-complete --stack-name neo-cycle-lambda ; fi
-      - aws cloudformation create-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND
-      - aws cloudformation wait stack-create-complete --stack-name neo-cycle-lambda
+      - aws cloudformation deploy
+          --stack-name neo-cycle-lambda
+          --template-file /Lambda/lambda.yaml
+          --parameter-overrides ObjectKeyPrefix=${CODEBUILD_BUILD_NUMBER}
+          --capabilities CAPABILITY_AUTO_EXPAND
       - cd ..
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,8 +16,7 @@ phases:
       - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
       - cd ../../neo-cycle-infra
       - res=$(aws cloudformation describe-stacks --stack-name neo-cycle-lambda)
-      - |
-        if [[ $res =~ COMPLETE ]] ; then aws cloudformation update-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-update-complete --stack-name neo-cycle-lambda ;
+      - if [[ $res =~ COMPLETE ]] ; then aws cloudformation update-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-update-complete --stack-name neo-cycle-lambda ;
 else aws cloudformation create-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-create-complete --stack-name neo-cycle-lambda ; fi
       - cd ..
   build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,21 +17,8 @@ phases:
       - cd ../../neo-cycle-infra
       - res=$(aws cloudformation describe-stacks --stack-name neo-cycle-lambda)
       - |
-        if [[ $res =~ COMPLETE ]] ; then
-          aws cloudformation update-stack
-            --stack-name neo-cycle-lambda
-            --template-body file://Lambda/lambda.yaml
-            --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER}
-            --capabilities CAPABILITY_AUTO_EXPAND ;
-          aws cloudformation wait stack-update-complete --stack-name neo-cycle-lambda ;
-        else 
-          aws cloudformation create-stack
-            --stack-name neo-cycle-lambda
-            --template-body file://Lambda/lambda.yaml
-            --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER}
-            --capabilities CAPABILITY_AUTO_EXPAND ;
-          aws cloudformation wait stack-create-complete --stack-name neo-cycle-lambda ;
-        fi
+        if [[ $res =~ COMPLETE ]] ; then aws cloudformation update-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-update-complete --stack-name neo-cycle-lambda ;
+else aws cloudformation create-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-create-complete --stack-name neo-cycle-lambda ; fi
       - cd ..
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,7 +16,9 @@ phases:
       - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
       - cd ../../neo-cycle-infra
       - res=$(aws cloudformation describe-stacks --stack-name neo-cycle-lambda)
-      - if [[ $res =~ COMPLETE ]] ; then aws cloudformation update-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-update-complete --stack-name neo-cycle-lambda ; else aws cloudformation create-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-create-complete --stack-name neo-cycle-lambda ; fi
+      - if [[ $res =~ COMPLETE ]] ; then aws cloudformation update-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-update-complete --stack-name neo-cycle-lambda ; fi
+      - aws cloudformation create-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND
+      - aws cloudformation wait stack-create-complete --stack-name neo-cycle-lambda
       - cd ..
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,8 +16,7 @@ phases:
       - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
       - cd ../../neo-cycle-infra
       - res=$(aws cloudformation describe-stacks --stack-name neo-cycle-lambda)
-      - if [[ $res =~ COMPLETE ]] ; then aws cloudformation update-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-update-complete --stack-name neo-cycle-lambda ;
-else aws cloudformation create-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-create-complete --stack-name neo-cycle-lambda ; fi
+      - if [[ $res =~ COMPLETE ]] ; then aws cloudformation update-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-update-complete --stack-name neo-cycle-lambda ; else aws cloudformation create-stack --stack-name neo-cycle-lambda --template-body file://Lambda/lambda.yaml --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} --capabilities CAPABILITY_AUTO_EXPAND ; aws cloudformation wait stack-create-complete --stack-name neo-cycle-lambda ; fi
       - cd ..
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,20 +17,20 @@ phases:
       - cd ../../neo-cycle-infra
       - res=$(aws cloudformation describe-stacks --stack-name neo-cycle-lambda)
       - |
-        if [[ $res =~ COMPLETE ]]; then
+        if [[ $res =~ COMPLETE ]] ; then
           aws cloudformation update-stack
             --stack-name neo-cycle-lambda
             --template-body file://Lambda/lambda.yaml
             --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER}
-            --capabilities CAPABILITY_AUTO_EXPAND
-          aws cloudformation wait stack-update-complete --stack-name neo-cycle-lambda
+            --capabilities CAPABILITY_AUTO_EXPAND ;
+          aws cloudformation wait stack-update-complete --stack-name neo-cycle-lambda ;
         else 
           aws cloudformation create-stack
             --stack-name neo-cycle-lambda
             --template-body file://Lambda/lambda.yaml
             --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER}
-            --capabilities CAPABILITY_AUTO_EXPAND
-          aws cloudformation wait stack-create-complete --stack-name neo-cycle-lambda
+            --capabilities CAPABILITY_AUTO_EXPAND ;
+          aws cloudformation wait stack-create-complete --stack-name neo-cycle-lambda ;
         fi
       - cd ..
   build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,8 +16,8 @@ phases:
       - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
       - cd ../../neo-cycle-infra
       - res=$(aws cloudformation describe-stacks --stack-name neo-cycle-lambda)
-      - if [[ $res =~ COMPLETE ]];
-        then
+      - |
+        if [[ $res =~ COMPLETE ]]; then
           aws cloudformation update-stack
             --stack-name neo-cycle-lambda
             --template-body file://Lambda/lambda.yaml
@@ -29,7 +29,7 @@ phases:
             --stack-name neo-cycle-lambda
             --template-body file://Lambda/lambda.yaml
             --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER}
-            --capabilities CAPABILITY_AUTO_EXPAND;
+            --capabilities CAPABILITY_AUTO_EXPAND
           aws cloudformation wait stack-create-complete --stack-name neo-cycle-lambda
         fi
       - cd ..

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -20,7 +20,7 @@ phases:
           --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER}
           --capabilities CAPABILITY_AUTO_EXPAND
       - aws cloudformation wait stack-create-complete
-        --stack-name presto-lambda-${ENV_NAME}
+        --stack-name neo-cycle-lambda
       - cd ..
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,7 +15,7 @@ phases:
       - zip -r Deploy.zip ./
       - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
       - cd ../../neo-cycle-infra
-      - res=$(aws cloudformation describe-stack --stack-name neo-cycle-lambda)
+      - res=$(aws cloudformation describe-stacks --stack-name neo-cycle-lambda)
       - if [[ $res =~ COMPLETE ]];
         then
           aws cloudformation update-stack

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,38 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      nodejs: 10
+  pre_build:
+    commands:
+      - cd neo-cycle-client
+      - if [ -e /tmp/node_modules.tar ]; then tar xf /tmp/node_modules.tar; fi
+      - npm install
+      - cd ../neo-cycle-lambda
+      - cd ./SessionMaintainer
+      - zip -r Deploy.zip ./
+      - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
+      - cd ../../neo-cycle-infra
+      - aws cloudformation create-stack \
+          --stack-name neo-cycle-lambda \
+          --template-body file://Lambda/lambda.yaml \
+          --parameters ParameterKey=BucketKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} \
+          --capabilities CAPABILITY_AUTO_EXPAND \
+      - aws cloudformation wait stack-create-complete \
+        --stack-name presto-lambda-${ENV_NAME} \
+      - cd ../..
+  build:
+    commands:
+      - cd neo-cycle-client
+      - npm run build
+  post_build:
+    commands:
+      - tar cf /tmp/node_modules.tar node_modules
+artifacts:
+  files:
+    - '**/*'
+  base-directory: neo-cycle-client/dist
+cache:
+  paths:
+    - /tmp/node_modules.tar

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,14 +14,14 @@ phases:
       - zip -r Deploy.zip ./
       - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
       - cd ../../neo-cycle-infra
-      - aws cloudformation create-stack \
-          --stack-name neo-cycle-lambda \
-          --template-body file://Lambda/lambda.yaml \
-          --parameters ParameterKey=BucketKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER} \
-          --capabilities CAPABILITY_AUTO_EXPAND \
-      - aws cloudformation wait stack-create-complete \
-        --stack-name presto-lambda-${ENV_NAME} \
-      - cd ../..
+      - aws cloudformation create-stack
+          --stack-name neo-cycle-lambda
+          --template-body file://Lambda/lambda.yaml
+          --parameters ParameterKey=BucketKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER}
+          --capabilities CAPABILITY_AUTO_EXPAND
+      - aws cloudformation wait stack-create-complete
+        --stack-name presto-lambda-${ENV_NAME}
+      - cd ..
   build:
     commands:
       - cd neo-cycle-client

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,7 +17,7 @@ phases:
       - cd ../../neo-cycle-infra
       - aws cloudformation deploy
           --stack-name neo-cycle-lambda
-          --template-file file://Lambda/lambda.yaml
+          --template-file Lambda/lambda.yaml
           --parameter-overrides ObjectKeyPrefix=${CODEBUILD_BUILD_NUMBER}
           --capabilities CAPABILITY_AUTO_EXPAND
       - cd ..

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,13 +15,23 @@ phases:
       - zip -r Deploy.zip ./
       - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
       - cd ../../neo-cycle-infra
-      - aws cloudformation create-stack
-          --stack-name neo-cycle-lambda
-          --template-body file://Lambda/lambda.yaml
-          --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER}
-          --capabilities CAPABILITY_AUTO_EXPAND
-      - aws cloudformation wait stack-create-complete
-        --stack-name neo-cycle-lambda
+      - res=$(aws cloudformation describe-stack --stack-name neo-cycle-lambda)
+      - if [[ $res =~ COMPLETE ]];
+        then
+          aws cloudformation update-stack
+            --stack-name neo-cycle-lambda
+            --template-body file://Lambda/lambda.yaml
+            --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER}
+            --capabilities CAPABILITY_AUTO_EXPAND
+          aws cloudformation wait stack-update-complete --stack-name neo-cycle-lambda
+        else 
+          aws cloudformation create-stack
+            --stack-name neo-cycle-lambda
+            --template-body file://Lambda/lambda.yaml
+            --parameters ParameterKey=ObjectKeyPrefix,ParameterValue=${CODEBUILD_BUILD_NUMBER}
+            --capabilities CAPABILITY_AUTO_EXPAND;
+          aws cloudformation wait stack-create-complete --stack-name neo-cycle-lambda
+        fi
       - cd ..
   build:
     commands:

--- a/neo-cycle-infra/CodePipeline/code-pipeline.yaml
+++ b/neo-cycle-infra/CodePipeline/code-pipeline.yaml
@@ -30,7 +30,7 @@ Parameters:
 Mappings:
   StackConfig:
     NameTag:
-      Value: ftf-web-management
+      Value: neo-cycle
 
 ######################################################
 # Resources
@@ -52,7 +52,7 @@ Resources:
               - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}-build:*
           - Effect: Allow
             Resource:
-              - !Sub arn:aws:s3:::codepipeline-${AWS::Region}-*
+              - "*"
             Action:
               - s3:PutObject
               - s3:GetObject
@@ -134,7 +134,7 @@ Resources:
                   - s3:*
                   - iam:PassRole
 
-  FtfWebManagementPipeline:
+  NeoCyclePipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
       Name: !Sub

--- a/neo-cycle-infra/CodePipeline/code-pipeline.yaml
+++ b/neo-cycle-infra/CodePipeline/code-pipeline.yaml
@@ -64,6 +64,11 @@ Resources:
               - "*"
             Action:
               - cloudformation:*
+          - Effect: Allow
+            Resource:
+              - "*"
+            Action:
+              - lambda:GetFunction
 
   RoleCodeBuildService:
     Type: AWS::IAM::Role

--- a/neo-cycle-infra/CodePipeline/code-pipeline.yaml
+++ b/neo-cycle-infra/CodePipeline/code-pipeline.yaml
@@ -69,6 +69,14 @@ Resources:
               - "*"
             Action:
               - lambda:GetFunction
+              - lambda:CreateFunction
+              - lambda:PutFunctionConcurrency
+          - Effect: Allow
+            Resource:
+              # LambdaにアタッチするRoleが増えるごとにここに追加していく
+              - !ImportValue RoleSessionMaintainerArn
+            Action:
+              - iam:PassRole
 
   RoleCodeBuildService:
     Type: AWS::IAM::Role

--- a/neo-cycle-infra/CodePipeline/code-pipeline.yaml
+++ b/neo-cycle-infra/CodePipeline/code-pipeline.yaml
@@ -1,0 +1,197 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+    CodePipeline for deployment client and lambda.
+
+######################################################
+# Parameters:
+######################################################
+Parameters:
+  GitHubRepoName:
+    Type: String
+    Default: neo-cycle
+  GitHubBranchName:
+    Type: String
+    Default: dev
+  GitHubOAuthToken:
+    Type: String
+  S3Bucket:
+    Type: String
+    Default: cycle.blog-neo.com
+  NameTag:
+    Type: String
+    Default: neo-cycle
+    AllowedValues:
+      - neo-cycle
+
+######################################################
+# Mappings
+######################################################
+Mappings:
+  StackConfig:
+    NameTag:
+      Value: ftf-web-management
+
+######################################################
+# Resources
+######################################################
+Resources:
+  CodeBuildBasePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource:
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}}-build
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}-build:*
+          - Effect: Allow
+            Resource:
+              - !Sub arn:aws:s3:::codepipeline-${AWS::Region}-*
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+              - s3:GetObjectVersion
+              - s3:GetBucketAcl
+              - s3:GetBucketLocation
+          - Effect: Allow
+            Resource:
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}}-build
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}-build:*
+            Action:
+              - cloudformation:*
+
+  RoleCodeBuildService:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub role-${NameTag}-codebuild
+      ManagedPolicyArns:
+        - !Ref CodeBuildBasePolicy
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: codebuild.amazonaws.com
+
+  NeoCycleBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Source:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Type: LINUX_CONTAINER
+        Image: aws/codebuild/standard:2.0-1.13.0
+      ServiceRole: !GetAtt RoleCodeBuildService.Arn
+      Name: !Sub
+        - ${NameTag}-build
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ]
+        }
+      Source:
+        Type: CODEPIPELINE
+
+  CodePipelineServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub role-${NameTag}-code-pipeline
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codepipeline.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: SamplePipelinePolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Resource:
+                  - !Sub arn:aws:s3:::${S3Bucket}/*
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:GetBucketVersioning
+              - Resource: "*"
+                Effect: Allow
+                Action:
+                  - cloudformation:*
+                  - codedeploy:*
+                  - codebuild:*
+                  - s3:*
+                  - iam:PassRole
+
+  FtfWebManagementPipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      Name: !Sub
+        - ${NameTag}
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ]
+        }
+      ArtifactStore:
+        Type: S3
+        Location: codepipeline-ap-northeast-1-299374294168
+      RoleArn: !GetAtt CodePipelineServiceRole.Arn
+      RestartExecutionOnUpdate: false
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: Source
+              ActionTypeId:
+                Category: Source
+                Owner: ThirdParty
+                Provider: GitHub
+                Version : 1
+              Configuration:
+                Owner: neo0222
+                Repo: !Ref GitHubRepoName
+                Branch: !Ref GitHubBranchName
+                OAuthToken: !Ref GitHubOAuthToken #GitHubでPersonal Access Tokenを発行する。
+                PollForSourceChanges: true
+              OutputArtifacts:
+                - Name: SourceArtifact
+              Region: ap-northeast-1
+              RunOrder: 1
+        - Name: Build
+          Actions:
+            - Name: Build
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref NeoCycleBuildProject
+              InputArtifacts:
+                - Name: SourceArtifact
+              OutputArtifacts:
+                - Name: BuildArtifacts
+              RunOrder: 1
+        - Name: Deploy
+          Actions:
+            - Name: Deploy
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: S3
+              Configuration:
+                BucketName: !Ref S3Bucket
+                Extract: true
+              InputArtifacts:
+                - Name: BuildArtifacts
+              RunOrder: 1

--- a/neo-cycle-infra/CodePipeline/code-pipeline.yaml
+++ b/neo-cycle-infra/CodePipeline/code-pipeline.yaml
@@ -71,6 +71,8 @@ Resources:
               - lambda:GetFunction
               - lambda:CreateFunction
               - lambda:PutFunctionConcurrency
+              - lambda:UpdateFunctionCode
+              - lambda:GetFunctionConfiguration
           - Effect: Allow
             Resource:
               # LambdaにアタッチするRoleが増えるごとにここに追加していく

--- a/neo-cycle-infra/CodePipeline/code-pipeline.yaml
+++ b/neo-cycle-infra/CodePipeline/code-pipeline.yaml
@@ -61,8 +61,7 @@ Resources:
               - s3:GetBucketLocation
           - Effect: Allow
             Resource:
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}}-build
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}-build:*
+              - "*"
             Action:
               - cloudformation:*
 

--- a/neo-cycle-infra/IAM/iam.yaml
+++ b/neo-cycle-infra/IAM/iam.yaml
@@ -61,6 +61,6 @@ Resources:
 #################################
 Outputs:
   RoleSessionMaintainerArn:
-    Value: !Ref RoleSessionMaintainer
+    Value: !GetAtt RoleSessionMaintainer.Arn
     Export:
       Name: RoleSessionMaintainerArn

--- a/neo-cycle-infra/IAM/iam.yaml
+++ b/neo-cycle-infra/IAM/iam.yaml
@@ -1,0 +1,66 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Mappings:
+  StackConfig:
+    ManagedPolicyArns:
+      AWSLambdaBasicExecutionRole: arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+Resources:
+  #-----------------------
+  # ポリシー作成
+  #-----------------------
+  NeoCycleSessionTablePutItemPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: authorize to put item into session dynamodb 
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - dynamodb:PutItem
+            Resource:
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/neo-cycle-SESSION"
+
+  NeoCycleGetParameterPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: authorize to get parameter from ssm
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - ssm:getParameter
+            Resource:
+              - arn:aws:ssm:ap-northeast-1:010660485109:parameter/neo-cycle/memberId
+              - arn:aws:ssm:ap-northeast-1:010660485109:parameter/neo-cycle/password
+              - arn:aws:ssm:ap-northeast-1:010660485109:parameter/neo-cycle/php-url
+
+  #-----------------------
+  # ロールの作成
+  #-----------------------
+  RoleSessionMaintainer:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: role-session-maintainer
+      ManagedPolicyArns:
+        - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
+        - !Ref NeoCycleSessionTablePutItemPolicy
+        - !Ref NeoCycleGetParameterPolicy
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: lambda.amazonaws.com
+
+#################################
+# Outputs
+#################################
+Outputs:
+  RoleSessionMaintainerArn:
+    Value: !Ref RoleSessionMaintainer
+    Export:
+      Name: RoleSessionMaintainerArn

--- a/neo-cycle-infra/Lambda/cloudwatch-events.yaml
+++ b/neo-cycle-infra/Lambda/cloudwatch-events.yaml
@@ -1,0 +1,32 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  AWS Lambda
+
+######################################################
+# Parameters:
+######################################################
+Parameters:
+  ObjectKeyPrefix:
+    Type: String
+
+######################################################
+# Resources
+######################################################
+Resources:
+  LambdaSessionMaintainerScheduleEvent:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: ’schedule event for lambda session maintainer’
+      ScheduleExpression: 'cron(0/30 * * * ? *)'
+      State: ENABLED
+      Targets:
+        - Arn: !ImportValue LambdaSessionMaintainerArn
+          Id: schedule-session-maintenance-target
+  LambdaSessionMaintainerInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties: 
+      Action: lambda:InvokeFunction
+      FunctionName: !ImportValue LambdaSessionMaintainerFunctionName
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt LambdaSessionMaintainerScheduleEvent.Arn

--- a/neo-cycle-infra/Lambda/lambda.yaml
+++ b/neo-cycle-infra/Lambda/lambda.yaml
@@ -1,0 +1,32 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  AWS Lambda
+
+######################################################
+# Parameters:
+######################################################
+Parameters:
+  ObjectKeyPrefix:
+    Type: String
+
+######################################################
+# Resources
+######################################################
+Resources:
+  LambdaSessionMaintainer:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: neo-cycle-lambda
+        S3Key: !Sub
+          - ${ObjectKeyPrefix}/SessionMaintainer/Deploy.zip
+          - {
+            ObjectKeyPrefix: !Ref ObjectKeyPrefix
+          }
+      FunctionName: SessionMaintainer
+      Handler: index.handler
+      ReservedConcurrentExecutions: 1
+      Role: !ImportValue RoleLambdaFoodDynamoArn
+      Runtime: nodejs12.x
+      Timeout: 10

--- a/neo-cycle-infra/Lambda/lambda.yaml
+++ b/neo-cycle-infra/Lambda/lambda.yaml
@@ -27,6 +27,6 @@ Resources:
       FunctionName: SessionMaintainer
       Handler: index.handler
       ReservedConcurrentExecutions: 1
-      Role: !ImportValue RoleLambdaFoodDynamoArn
+      Role: !ImportValue RoleSessionMaintainerArn
       Runtime: nodejs12.x
       Timeout: 10

--- a/neo-cycle-infra/Lambda/lambda.yaml
+++ b/neo-cycle-infra/Lambda/lambda.yaml
@@ -31,19 +31,15 @@ Resources:
       Runtime: nodejs12.x
       Timeout: 10
   
-  LambdaSessionMaintainerScheduleEvent:
-    Type: AWS::Events::Rule
-    Properties:
-      Description: ’schedule event for lambda session maintainer’
-      ScheduleExpression: 'cron(0/30 * * * ? *)'
-      State: ENABLED
-      Targets:
-        - Arn: !GetAtt LambdaSessionMaintainer.Arn
-          Id: schedule-session-maintenance-target
-  LambdaSessionMaintainerInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties: 
-      Action: lambda:InvokeFunction
-      FunctionName: !Ref LambdaSessionMaintainer
-      Principal: events.amazonaws.com
-      SourceArn: !GetAtt LambdaSessionMaintainerScheduleEvent.Arn
+#################################
+# Outputs
+#################################
+Outputs:
+  LambdaSessionMaintainerArn:
+    Value: !GetAtt LambdaSessionMaintainer.Arn
+    Export:
+      Name: LambdaSessionMaintainerArn
+  LambdaSessionMaintainerFunctionName:
+    Value: !Ref LambdaSessionMaintainer
+    Export:
+      Name: LambdaSessionMaintainerFunctionName

--- a/neo-cycle-infra/Lambda/lambda.yaml
+++ b/neo-cycle-infra/Lambda/lambda.yaml
@@ -30,3 +30,20 @@ Resources:
       Role: !ImportValue RoleSessionMaintainerArn
       Runtime: nodejs12.x
       Timeout: 10
+  
+  LambdaSessionMaintainerScheduleEvent:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: ’schedule event for lambda session maintainer’
+      ScheduleExpression: 'cron(0/30 * * * ? *)'
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt LambdaSessionMaintainer.Arn
+          Id: schedule-session-maintenance-target
+  LambdaSessionMaintainerInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties: 
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref LambdaSessionMaintainer
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt LambdaSessionMaintainerScheduleEvent.Arn

--- a/neo-cycle-infra/Middleware/dynamodb.yaml
+++ b/neo-cycle-infra/Middleware/dynamodb.yaml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  FtfWebManagementRecorder
+  and FtfWebManagement DynamoDB setup
+
+######################################################
+# Resources
+######################################################
+Resources:
+  #----------------------------------------------
+  # SESSION
+  #----------------------------------------------
+  FOOD:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      KeySchema:
+        - AttributeName: memberId
+          KeyType: HASH
+      AttributeDefinitions:
+        - AttributeName: memberId
+          AttributeType: S
+      TableName: neo-cycle-SESSION
+      BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      SSESpecification:
+        SSEEnabled: true

--- a/neo-cycle-lambda/SessionMaintainer/index.js
+++ b/neo-cycle-lambda/SessionMaintainer/index.js
@@ -1,0 +1,88 @@
+const AWS = require('aws-sdk');
+const docClient = new AWS.DynamoDB.DocumentClient({
+  region: 'ap-northeast-1'
+});
+const ssm = new AWS.SSM();
+const axios = require('axios');
+
+const sessionTableName = 'neo-cycle-SESSION';
+
+exports.handler = async (event, context) => {
+  if (event.warmup) {
+      console.log("This is warm up.");
+  } else {
+      console.log(`[event]: ${JSON.stringify(event)}`);
+  }
+  return await main(event, context);
+};
+
+async function main(event, context) {
+  const { memberId, password } = await retrieveUserInfoFromSsm();
+  const sessionId = await retrieveSessionId(memberId, password);
+  await putSessionId(memberId, sessionId);
+  const response = {
+    statusCode: 200,
+    body: {
+    },
+    headers: {
+        "Access-Control-Allow-Origin": '*'
+    }
+  };
+  return response;
+}
+
+async function retrieveUserInfoFromSsm() {
+  const memberId = await ssm.getParameter({
+    Name: '/neo-cycle/memberId',
+    WithDecryption: false,
+  }).promise();
+  const password = await ssm.getParameter({
+    Name: '/neo-cycle/password',
+    WithDecryption: true,
+  }).promise();
+  return { memberId: memberId.Parameter.Value, password: password.Parameter.Value };
+}
+
+async function retrieveSessionId(memberId, password) {
+  const url = await ssm.getParameter({
+    Name: '/neo-cycle/php-url',
+    WithDecryption: false,
+  }).promise();
+  const params = new URLSearchParams()
+  params.append('EventNo', 21401);
+  params.append('GarblePrevention', '%EF%BC%B0%EF%BC%AF%EF%BC%B3%EF%BC%B4%E3%83%87%E3%83%BC%E3%82%BF');
+  params.append('MemberID', memberId);
+  params.append('Password', password);
+  const config = {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3'
+    }
+  }
+  try {
+    const res = await axios.post(url.Parameter.Value, params, config);
+    const html = res.data;
+    const sessionId = html.substr(html.indexOf('"SessionID" value="') + 19, 35+memberId.length);
+    return sessionId;
+  }
+  catch (error) {
+    throw error;
+  }
+}
+
+async function putSessionId(memberId, sessionId) {
+  const params = {
+    TableName: sessionTableName,
+    Item: {
+      memberId: memberId,
+      sessionId: sessionId
+    }
+  };
+  try {
+    await docClient.put(params).promise();
+  }
+  catch (error) {
+    throw error;
+  }
+}
+

--- a/neo-cycle-lambda/SessionMaintainer/index.js
+++ b/neo-cycle-lambda/SessionMaintainer/index.js
@@ -62,7 +62,7 @@ async function retrieveSessionId(memberId, password) {
   try {
     const res = await axios.post(url.Parameter.Value, params, config);
     const html = res.data;
-    const sessionId = html.substr(html.indexOf('"SessionID" value="') + 19, 35+memberId.length);
+    const sessionId = html.substr(html.indexOf('"SessionID" value="') + 19, 36+memberId.length);
     return sessionId;
   }
   catch (error) {

--- a/neo-cycle-lambda/SessionMaintainer/package-lock.json
+++ b/neo-cycle-lambda/SessionMaintainer/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "sessionmaintainer",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    }
+  }
+}

--- a/neo-cycle-lambda/SessionMaintainer/package.json
+++ b/neo-cycle-lambda/SessionMaintainer/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sessionmaintainer",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^0.19.2"
+  }
+}


### PR DESCRIPTION
## やったこと
- 30分ごとにログインを実施して取得したセッション情報を保持する機構を構築
   - ログイン〜セッション情報永続化→Lambda（SessionMaintainer）
   - 30分ごとの実行→CloudWatch EventsでLambdaを自動コール
- インフラ構築
   - DynamoDB→セッション情報の永続化用
   - Lambda→セッション情報永続化用
   - CodePipeline＋CodeBuild→Lambdaと画面のデプロイ用
   - IAM→Lambdaの実行ロール用
   - CloudWatch Events→Lambda定期実行用

## 詳細
### SessionMaintainer
- SSM Parameter Storeに保持しているシェアサイクルサービスのユーザID、パスワード、Web版アプリのURLを取得し、ログインを実行する。（POSTでコールする）
- 取得したhtmlに埋め込まれているセッションIDを見つけて、DynamoにPUT
### CodeBuild
- LambdaとClientのデプロイを一緒にやっている。
- Lambdaが増えるごとに修正が必要
- 更新が正常に行われることは確認済み
- cloudformationのCLIコマンド：`aws cloudformation deploy`を使うと、更新・作成に関わらずスタックを最新化してくれる。（create-stack/update-stack/wait hogeはDeprecated！）

### CodePipeline
- CodeBuildにアタッチするPolicyに手こずった。何を要求されるか回すまでわからないので、デバッグが発生しがち。buildspecに関しては一旦コミットしないと反映されないので、大変。
- LambdaにRoleを紐づけるには`iam:PassRole`ポリシーのアタッチが必要。

### Lambda
- ロールはLambdaごとに作成することにしたので`iam.yaml`に新規作成するごとに増やしていく予定。セキュアなアプリを目指しましょう！
- Policyアタッチするときは`sts:assumeRple`も忘れない。