### PR TITLE
ポート一覧取得API

### DIFF
--- a/neo-cycle-infra/ApiGateway/api-gateway.yaml
+++ b/neo-cycle-infra/ApiGateway/api-gateway.yaml
@@ -1,0 +1,126 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  API Gateway
+
+######################################################
+# Parameters:
+######################################################
+Parameters:
+  NameTag:
+    Type: String
+    Default: neo-cycle
+    AllowedValues:
+      - neo-cycle
+
+######################################################
+# Mappings
+######################################################
+Mappings:
+  StackConfig:
+    NameTag:
+      Value: neo-cycle
+
+######################################################
+# Resources
+######################################################
+Resources:
+  ######################################################
+  # Rest API
+  ######################################################
+  NeoCycleRestAPI:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: !Sub 
+        - ${NameTag}
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value]
+        }
+      EndpointConfiguration:
+        Types:
+          - EDGE
+
+
+  ######################################################
+  # Parkings
+  #   - Resource
+  #     - path: /parkings
+  #   - Method
+  #     - POST
+  #     - OPTION(for enable CORS)
+  #   - Lambda Permission
+  ######################################################
+  ParkingsResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref NeoCycleRestAPI
+      ParentId: !GetAtt
+        - NeoCycleRestAPI
+        - RootResourceId
+      PathPart: parkings
+
+  ParkingsPostMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      HttpMethod: POST
+      ResourceId: !Ref ParkingsResource
+      RestApiId: !Ref NeoCycleRestAPI
+      MethodResponses: 
+        - StatusCode: 200
+          ResponseParameters:
+            "method.response.header.Access-Control-Allow-Origin" : true
+      Integration:
+        Type: AWS
+        Uri: !Sub
+          - arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaParkingRetrieverArn}/invocations
+          - {
+            LambdaParkingRetrieverArn: {
+              'Fn::ImportValue': LambdaParkingRetrieverArn
+            }
+          }
+        IntegrationHttpMethod: POST
+        IntegrationResponses:
+          - StatusCode: 200
+            ResponseParameters:
+              'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
+    DependsOn: LambdaParkingsRegistererPermission
+
+  ParkingsOptionsMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      RestApiId:
+        Ref: NeoCycleRestAPI
+      ResourceId:
+        Ref: ParkingsResource
+      HttpMethod: OPTIONS
+      Integration:
+        IntegrationResponses:
+        - StatusCode: 200
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+            method.response.header.Access-Control-Allow-Methods: "'POST,OPTIONS'"
+            method.response.header.Access-Control-Allow-Origin: "'*'"
+          ResponseTemplates:
+            application/json: ''
+        PassthroughBehavior: WHEN_NO_MATCH
+        RequestTemplates:
+          application/json: '{"statusCode": 200}'
+        Type: MOCK
+      MethodResponses:
+      - StatusCode: 200
+        ResponseModels:
+          application/json: 'Empty'
+        ResponseParameters:
+          method.response.header.Access-Control-Allow-Headers: false
+          method.response.header.Access-Control-Allow-Methods: false
+          method.response.header.Access-Control-Allow-Origin: false
+    DependsOn: ParkingsResource
+
+  LambdaParkingsRegistererPermission:
+    Type: AWS::Lambda::Permission
+    Properties: 
+      Action: lambda:InvokeFunction
+      FunctionName: !ImportValue LambdaParkingRetrieverFunctionName
+      Principal: apigateway.amazonaws.com

--- a/neo-cycle-infra/CodePipeline/code-pipeline.yaml
+++ b/neo-cycle-infra/CodePipeline/code-pipeline.yaml
@@ -77,6 +77,7 @@ Resources:
             Resource:
               # LambdaにアタッチするRoleが増えるごとにここに追加していく
               - !ImportValue RoleSessionMaintainerArn
+              - !ImportValue RoleParkingRetrieverArn
             Action:
               - iam:PassRole
 

--- a/neo-cycle-infra/IAM/iam.yaml
+++ b/neo-cycle-infra/IAM/iam.yaml
@@ -69,10 +69,10 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
   
-  RolePortRetriever:
+  RoleParkingRetriever:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: role-port-retriever
+      RoleName: role-parking-retriever
       ManagedPolicyArns:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
         - !Ref NeoCycleSessionTableGetItemPolicy
@@ -94,7 +94,7 @@ Outputs:
     Export:
       Name: RoleSessionMaintainerArn
 
-  RolePortRetrieverArn:
-    Value: !GetAtt RolePortRetriever.Arn
+  RoleParkingRetrieverArn:
+    Value: !GetAtt RoleParkingRetriever.Arn
     Export:
-      Name: RolePortRetrieverArn
+      Name: RoleParkingRetrieverArn


### PR DESCRIPTION
## やったこと
- API Gatewayを作成していろいろなところからLambdaをinvokeできるようにした

## やばいこと
- いろいろなところから叩けてしまうので、やばい。今回はアプリ側でCognito認証を行なっていないのでCognito認証はできないから、API GatewayのリソースポリシーでIP制限をする必要がある。今は参照系しかないが、自転車予約、予約キャンセルのAPIを作成するまでに実施する。