### PR TITLE
複数環境構築に対応（AWSリソース側）

### DIFF
--- a/neo-cycle-infra/ApiGateway/api-gateway.yaml
+++ b/neo-cycle-infra/ApiGateway/api-gateway.yaml
@@ -12,6 +12,12 @@ Parameters:
     Default: neo-cycle
     AllowedValues:
       - neo-cycle
+  EnvName:
+    Type: String
+    AllowedValues:
+      - dev
+      - prod
+    Description: Enter profile.
 
 ######################################################
 # Mappings
@@ -32,9 +38,10 @@ Resources:
     Type: AWS::ApiGateway::RestApi
     Properties:
       Name: !Sub 
-        - ${NameTag}
+        - ${NameTag}-${EnvName}-api-gateway
         - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value]
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
         }
       EndpointConfiguration:
         Types:
@@ -76,7 +83,8 @@ Resources:
           - arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaParkingRetrieverArn}/invocations
           - {
             LambdaParkingRetrieverArn: {
-              'Fn::ImportValue': LambdaParkingRetrieverArn
+              'Fn::ImportValue':
+                !Sub "${NameTag}-${EnvName}-LambdaParkingRetrieverArn"
             }
           }
         IntegrationHttpMethod: POST
@@ -122,7 +130,13 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties: 
       Action: lambda:InvokeFunction
-      FunctionName: !ImportValue LambdaParkingRetrieverFunctionName
+      FunctionName: !ImportValue
+        Fn::Sub:
+          - ${NameTag}-${EnvName}-LambdaParkingRetrieverFunctionName
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
       Principal: apigateway.amazonaws.com
 
   ######################################################
@@ -160,7 +174,8 @@ Resources:
           - arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaReservationMakerArn}/invocations
           - {
             LambdaReservationMakerArn: {
-              'Fn::ImportValue': LambdaReservationMakerArn
+              'Fn::ImportValue':
+                !Sub "${NameTag}-${EnvName}-LambdaReservationMakerArn"
             }
           }
         IntegrationHttpMethod: POST
@@ -206,7 +221,13 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties: 
       Action: lambda:InvokeFunction
-      FunctionName: !ImportValue LambdaReservationMakerFunctionName
+      FunctionName: !ImportValue
+        Fn::Sub:
+          - ${NameTag}-${EnvName}-LambdaReservationMakerFunctionName
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
       Principal: apigateway.amazonaws.com
 
   ######################################################
@@ -244,7 +265,8 @@ Resources:
           - arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaReservationCancellerArn}/invocations
           - {
             LambdaReservationCancellerArn: {
-              'Fn::ImportValue': LambdaReservationCancellerArn
+              'Fn::ImportValue':
+                !Sub "${NameTag}-${EnvName}-LambdaReservationCancellerArn"
             }
           }
         IntegrationHttpMethod: POST
@@ -290,7 +312,13 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties: 
       Action: lambda:InvokeFunction
-      FunctionName: !ImportValue LambdaReservationCancellerFunctionName
+      FunctionName: !ImportValue
+        Fn::Sub:
+          - ${NameTag}-${EnvName}-LambdaReservationCancellerFunctionName
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
       Principal: apigateway.amazonaws.com
 
   ######################################################
@@ -328,7 +356,8 @@ Resources:
           - arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaStatusCheckerArn}/invocations
           - {
             LambdaStatusCheckerArn: {
-              'Fn::ImportValue': LambdaStatusCheckerArn
+              'Fn::ImportValue':
+                !Sub "${NameTag}-${EnvName}-LambdaStatusCheckerArn"
             }
           }
         IntegrationHttpMethod: POST
@@ -374,5 +403,11 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties: 
       Action: lambda:InvokeFunction
-      FunctionName: !ImportValue LambdaStatusCheckerFunctionName
+      FunctionName: !ImportValue
+        Fn::Sub:
+          - ${NameTag}-${EnvName}-LambdaStatusCheckerFunctionName
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
       Principal: apigateway.amazonaws.com

--- a/neo-cycle-infra/CodePipeline/code-pipeline.yaml
+++ b/neo-cycle-infra/CodePipeline/code-pipeline.yaml
@@ -17,12 +17,18 @@ Parameters:
     Type: String
   S3Bucket:
     Type: String
-    Default: cycle.blog-neo.com
+    Default: prod.neo-cycle.com
   NameTag:
     Type: String
     Default: neo-cycle
     AllowedValues:
       - neo-cycle
+  EnvName:
+    Type: String
+    AllowedValues:
+      - dev
+      - prod
+    Description: Enter profile.
 
 ######################################################
 # Mappings
@@ -48,8 +54,18 @@ Resources:
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource:
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}}-build
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}-build:*
+              - !Sub
+                - arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}-build
+                - {
+                  NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+                  EnvName: !Ref EnvName
+                }
+              - !Sub
+                - arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}-build:*
+                - {
+                  NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+                  EnvName: !Ref EnvName
+                }
           - Effect: Allow
             Resource:
               - "*"
@@ -76,18 +92,53 @@ Resources:
           - Effect: Allow
             Resource:
               # RoleをアタッチするLambdaが増えるごとにここに追加していく
-              - !ImportValue RoleSessionMaintainerArn
-              - !ImportValue RoleParkingRetrieverArn
-              - !ImportValue RoleReservationMakerArn
-              - !ImportValue RoleReservationCancellerArn
-              - !ImportValue RoleStatusCheckerArn
+              - !ImportValue
+                Fn::Sub:
+                  - ${NameTag}-${EnvName}-RoleSessionMaintainerArn
+                  - {
+                    NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+                    EnvName: !Ref EnvName
+                  }
+              - !ImportValue
+                Fn::Sub:
+                  - ${NameTag}-${EnvName}-RoleParkingRetrieverArn
+                  - {
+                    NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+                    EnvName: !Ref EnvName
+                  }
+              - !ImportValue
+                Fn::Sub:
+                  - ${NameTag}-${EnvName}-RoleReservationMakerArn
+                  - {
+                    NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+                    EnvName: !Ref EnvName
+                  }
+              - !ImportValue
+                Fn::Sub:
+                  - ${NameTag}-${EnvName}-RoleReservationCancellerArn
+                  - {
+                    NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+                    EnvName: !Ref EnvName
+                  }
+              - !ImportValue
+                Fn::Sub:
+                  - ${NameTag}-${EnvName}-RoleStatusCheckerArn
+                  - {
+                    NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+                    EnvName: !Ref EnvName
+                  }
             Action:
               - iam:PassRole
 
   RoleCodeBuildService:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub role-${NameTag}-codebuild
+      RoleName: !Sub
+        - role-${NameTag}-${EnvName}-codebuild
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
       ManagedPolicyArns:
         - !Ref CodeBuildBasePolicy
       AssumeRolePolicyDocument:
@@ -107,13 +158,17 @@ Resources:
         Type: CODEPIPELINE
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
+        EnvironmentVariables:
+          - Name: ENVIRONMENT_NAME
+            Value: !Ref EnvName
         Type: LINUX_CONTAINER
         Image: aws/codebuild/standard:2.0-1.13.0
       ServiceRole: !GetAtt RoleCodeBuildService.Arn
       Name: !Sub
-        - ${NameTag}-build
+        - ${NameTag}-${EnvName}-build
         - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ]
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
         }
       Source:
         Type: CODEPIPELINE
@@ -121,7 +176,12 @@ Resources:
   CodePipelineServiceRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub role-${NameTag}-code-pipeline
+      RoleName: !Sub
+        - role-${NameTag}-${EnvName}-code-pipeline
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
       Path: /
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -156,9 +216,10 @@ Resources:
     Type: AWS::CodePipeline::Pipeline
     Properties:
       Name: !Sub
-        - ${NameTag}
+        - ${NameTag}-${EnvName}-code-pipeline
         - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ]
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
         }
       ArtifactStore:
         Type: S3

--- a/neo-cycle-infra/IAM/iam.yaml
+++ b/neo-cycle-infra/IAM/iam.yaml
@@ -1,10 +1,29 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
+######################################################
+# Parameters:
+######################################################
+Parameters:
+  EnvName:
+    Type: String
+    AllowedValues:
+      - dev
+      - prod
+    Description: Enter profile.
+
+######################################################
+# Mappings:
+######################################################
 Mappings:
   StackConfig:
     ManagedPolicyArns:
       AWSLambdaBasicExecutionRole: arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+    NameTag:
+      Value: neo-cycle
 
+######################################################
+# Resources:
+######################################################
 Resources:
   #-----------------------
   # ポリシー作成
@@ -56,7 +75,12 @@ Resources:
   RoleSessionMaintainer:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: role-session-maintainer
+      RoleName: !Sub
+        - ${NameTag}-${EnvName}-session-maintainer-role
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
       ManagedPolicyArns:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
         - !Ref NeoCycleSessionTablePutItemPolicy
@@ -72,7 +96,12 @@ Resources:
   RoleParkingRetriever:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: role-parking-retriever
+      RoleName: !Sub
+        - ${NameTag}-${EnvName}-parking-retriever-role
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
       ManagedPolicyArns:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
         - !Ref NeoCycleSessionTableGetItemPolicy
@@ -88,7 +117,12 @@ Resources:
   RoleReservationMaker:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: role-reservation-maker
+      RoleName: !Sub
+        - ${NameTag}-${EnvName}-reservation-maker-role
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
       ManagedPolicyArns:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
         - !Ref NeoCycleSessionTableGetItemPolicy
@@ -104,7 +138,12 @@ Resources:
   RoleReservationCanceller:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: role-reservation-canceller
+      RoleName: !Sub
+        - ${NameTag}-${EnvName}-reservation-canceller-role
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
       ManagedPolicyArns:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
         - !Ref NeoCycleSessionTableGetItemPolicy
@@ -120,7 +159,12 @@ Resources:
   RoleStatusChecker:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: role-status-checker
+      RoleName: !Sub
+        - ${NameTag}-${EnvName}-status-checker-role
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
       ManagedPolicyArns:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
         - !Ref NeoCycleSessionTableGetItemPolicy
@@ -140,24 +184,49 @@ Outputs:
   RoleSessionMaintainerArn:
     Value: !GetAtt RoleSessionMaintainer.Arn
     Export:
-      Name: RoleSessionMaintainerArn
+      Name: !Sub
+        - ${NameTag}-${EnvName}-SessionMaintainerRoleArn
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
 
   RoleParkingRetrieverArn:
     Value: !GetAtt RoleParkingRetriever.Arn
     Export:
-      Name: RoleParkingRetrieverArn
+      Name: !Sub
+        - ${NameTag}-${EnvName}-ParkingRetrieverRoleArn
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
 
   RoleReservationMakerArn:
     Value: !GetAtt RoleReservationMaker.Arn
     Export:
-      Name: RoleReservationMakerArn
+      Name: !Sub
+        - ${NameTag}-${EnvName}-ReservationMakerRoleArn
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
 
   RoleReservationCancellerArn:
     Value: !GetAtt RoleReservationCanceller.Arn
     Export:
-      Name: RoleReservationCancellerArn
+      Name: !Sub
+        - ${NameTag}-${EnvName}-ReservationCancellerRoleArn
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
 
   RoleStatusCheckerArn:
     Value: !GetAtt RoleStatusChecker.Arn
     Export:
-      Name: RoleStatusCheckerArn
+      Name: !Sub
+        - ${NameTag}-${EnvName}-StatusCheckerRoleArn
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }

--- a/neo-cycle-infra/IAM/iam.yaml
+++ b/neo-cycle-infra/IAM/iam.yaml
@@ -185,7 +185,7 @@ Outputs:
     Value: !GetAtt RoleSessionMaintainer.Arn
     Export:
       Name: !Sub
-        - ${NameTag}-${EnvName}-SessionMaintainerRoleArn
+        - ${NameTag}-${EnvName}-RoleSessionMaintainerArn
         - {
           NameTag: !FindInMap [ StackConfig, NameTag, Value ],
           EnvName: !Ref EnvName
@@ -195,7 +195,7 @@ Outputs:
     Value: !GetAtt RoleParkingRetriever.Arn
     Export:
       Name: !Sub
-        - ${NameTag}-${EnvName}-ParkingRetrieverRoleArn
+        - ${NameTag}-${EnvName}-RoleParkingRetrieverArn
         - {
           NameTag: !FindInMap [ StackConfig, NameTag, Value ],
           EnvName: !Ref EnvName
@@ -205,7 +205,7 @@ Outputs:
     Value: !GetAtt RoleReservationMaker.Arn
     Export:
       Name: !Sub
-        - ${NameTag}-${EnvName}-ReservationMakerRoleArn
+        - ${NameTag}-${EnvName}-RoleReservationMakerArn
         - {
           NameTag: !FindInMap [ StackConfig, NameTag, Value ],
           EnvName: !Ref EnvName
@@ -215,7 +215,7 @@ Outputs:
     Value: !GetAtt RoleReservationCanceller.Arn
     Export:
       Name: !Sub
-        - ${NameTag}-${EnvName}-ReservationCancellerRoleArn
+        - ${NameTag}-${EnvName}-RoleReservationCancellerArn
         - {
           NameTag: !FindInMap [ StackConfig, NameTag, Value ],
           EnvName: !Ref EnvName
@@ -225,7 +225,7 @@ Outputs:
     Value: !GetAtt RoleStatusChecker.Arn
     Export:
       Name: !Sub
-        - ${NameTag}-${EnvName}-StatusCheckerRoleArn
+        - ${NameTag}-${EnvName}-RoleStatusCheckerArn
         - {
           NameTag: !FindInMap [ StackConfig, NameTag, Value ],
           EnvName: !Ref EnvName

--- a/neo-cycle-infra/Lambda/lambda.yaml
+++ b/neo-cycle-infra/Lambda/lambda.yaml
@@ -9,6 +9,20 @@ Description: >
 Parameters:
   ObjectKeyPrefix:
     Type: String
+  EnvName:
+    Type: String
+    AllowedValues:
+      - dev
+      - prod
+    Description: Enter profile.
+
+######################################################
+# Mappings:
+######################################################
+Mappings:
+  StackConfig:
+    NameTag:
+      Value: neo-cycle
 
 ######################################################
 # Resources
@@ -18,16 +32,32 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: neo-cycle-lambda
+        S3Bucket: !Sub
+          - ${NameTag}-${EnvName}-lambda
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
         S3Key: !Sub
           - ${ObjectKeyPrefix}/SessionMaintainer/Deploy.zip
           - {
             ObjectKeyPrefix: !Ref ObjectKeyPrefix
           }
-      FunctionName: SessionMaintainer
+      FunctionName: !Sub
+        - ${NameTag}-${EnvName}-SessionMaintainer
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
       Handler: index.handler
       ReservedConcurrentExecutions: 1
-      Role: !ImportValue RoleSessionMaintainerArn
+      Role: !ImportValue
+        Fn::Sub:
+          - ${NameTag}-${EnvName}-RoleSessionMaintainerArn
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
       Runtime: nodejs12.x
       Timeout: 10
 
@@ -35,7 +65,12 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: neo-cycle-lambda
+        S3Bucket: !Sub
+          - ${NameTag}-${EnvName}-lambda
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
         S3Key: !Sub
           - ${ObjectKeyPrefix}/ParkingRetriever/Deploy.zip
           - {
@@ -44,10 +79,21 @@ Resources:
       Environment:
         Variables:
           PARKING_IDS: 10124,10077,10507
-      FunctionName: ParkingRetriever
+      FunctionName: !Sub
+        - ${NameTag}-${EnvName}-ParkingRetriever
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+          }
       Handler: index.handler
       ReservedConcurrentExecutions: 1
-      Role: !ImportValue RoleParkingRetrieverArn
+      Role: !ImportValue
+        Fn::Sub:
+          - ${NameTag}-${EnvName}-RoleParkingRetrieverArn
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
       Runtime: nodejs12.x
       Timeout: 10
 
@@ -55,16 +101,32 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: neo-cycle-lambda
+        S3Bucket: !Sub
+          - ${NameTag}-${EnvName}-lambda
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
         S3Key: !Sub
           - ${ObjectKeyPrefix}/ReservationMaker/Deploy.zip
           - {
             ObjectKeyPrefix: !Ref ObjectKeyPrefix
           }
-      FunctionName: ReservationMaker
+      FunctionName: !Sub
+        - ${NameTag}-${EnvName}-ReservationMaker
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
       Handler: index.handler
       ReservedConcurrentExecutions: 1
-      Role: !ImportValue RoleReservationMakerArn
+      Role: !ImportValue
+        Fn::Sub:
+          - ${NameTag}-${EnvName}-RoleReservationMakerArn
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
       Runtime: nodejs12.x
       Timeout: 10
 
@@ -72,16 +134,32 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: neo-cycle-lambda
+        S3Bucket: !Sub
+          - ${NameTag}-${EnvName}-lambda
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
         S3Key: !Sub
           - ${ObjectKeyPrefix}/ReservationCanceller/Deploy.zip
           - {
             ObjectKeyPrefix: !Ref ObjectKeyPrefix
           }
-      FunctionName: ReservationCanceller
+      FunctionName: !Sub
+        - ${NameTag}-${EnvName}-ReservationCanceller
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
       Handler: index.handler
       ReservedConcurrentExecutions: 1
-      Role: !ImportValue RoleReservationCancellerArn
+      Role: !ImportValue
+        Fn::Sub:
+          - ${NameTag}-${EnvName}-RoleReservationCancellerArn
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
       Runtime: nodejs12.x
       Timeout: 10
 
@@ -89,16 +167,32 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: neo-cycle-lambda
+        S3Bucket: !Sub
+          - ${NameTag}-${EnvName}-lambda
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
         S3Key: !Sub
           - ${ObjectKeyPrefix}/StatusChecker/Deploy.zip
           - {
             ObjectKeyPrefix: !Ref ObjectKeyPrefix
           }
-      FunctionName: StatusChecker
+      FunctionName: !Sub
+        - ${NameTag}-${EnvName}-StatusChecker
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
       Handler: index.handler
       ReservedConcurrentExecutions: 1
-      Role: !ImportValue RoleStatusCheckerArn
+      Role: !ImportValue
+        Fn::Sub:
+          - ${NameTag}-${EnvName}-RoleStatusCheckerArn
+          - {
+            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+            EnvName: !Ref EnvName
+          }
       Runtime: nodejs12.x
       Timeout: 10
 
@@ -109,40 +203,90 @@ Outputs:
   LambdaSessionMaintainerArn:
     Value: !GetAtt LambdaSessionMaintainer.Arn
     Export:
-      Name: LambdaSessionMaintainerArn
+      Name: !Sub
+        - ${NameTag}-${EnvName}-LambdaSessionMaintainerArn
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
   LambdaSessionMaintainerFunctionName:
     Value: !Ref LambdaSessionMaintainer
     Export:
-      Name: LambdaSessionMaintainerFunctionName
+      Name: !Sub
+        - ${NameTag}-${EnvName}-LambdaSessionMaintainerFunctionName
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
   LambdaParkingRetrieverArn:
     Value: !GetAtt LambdaParkingRetriever.Arn
     Export:
-      Name: LambdaParkingRetrieverArn
+      Name: !Sub
+        - ${NameTag}-${EnvName}-LambdaParkingRetrieverArn
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
   LambdaParkingRetrieverFunctionName:
     Value: !Ref LambdaParkingRetriever
     Export:
-      Name: LambdaParkingRetrieverFunctionName
+      Name: !Sub
+        - ${NameTag}-${EnvName}-LambdaParkingRetrieverFunctionName
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
   LambdaReservationMakerArn:
     Value: !GetAtt LambdaReservationMaker.Arn
     Export:
-      Name: LambdaReservationMakerArn
+      Name: !Sub
+        - ${NameTag}-${EnvName}-LambdaReservationMakerArn
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
   LambdaReservationMakerFunctionName:
     Value: !Ref LambdaReservationMaker
     Export:
-      Name: LambdaReservationMakerFunctionName
+      Name: !Sub
+        - ${NameTag}-${EnvName}-LambdaReservationMakerFunctionName
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
   LambdaReservationCancellerArn:
     Value: !GetAtt LambdaReservationCanceller.Arn
     Export:
-      Name: LambdaReservationCancellerArn
+      Name: !Sub
+        - ${NameTag}-${EnvName}-LambdaReservationCancellerArn
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
   LambdaReservationCancellerFunctionName:
     Value: !Ref LambdaReservationCanceller
     Export:
-      Name: LambdaReservationCancellerFunctionName
+      Name: !Sub
+        - ${NameTag}-${EnvName}-LambdaReservationCancellerFunctionName
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
   LambdaStatusCheckerArn:
     Value: !GetAtt LambdaStatusChecker.Arn
     Export:
-      Name: LambdaStatusCheckerArn
+      Name: !Sub
+        - ${NameTag}-${EnvName}-LambdaStatusCheckerArn
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
   LambdaStatusCheckerName:
     Value: !Ref LambdaStatusChecker
     Export:
-      Name: LambdaStatusCheckerFunctionName
+      Name: !Sub
+        - ${NameTag}-${EnvName}-LambdaStatusCheckerFunctionName
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }

--- a/neo-cycle-infra/S3/s3-bucket.yaml
+++ b/neo-cycle-infra/S3/s3-bucket.yaml
@@ -1,0 +1,78 @@
+AWSTemplateFormatVersion: 2010-09-09
+######################################################
+# Parameters:
+######################################################
+Parameters:
+  S3HostingDomainName:
+    Type: String
+    Default: neo-cycle.com
+  EnvName:
+    Type: String
+    AllowedValues:
+      - dev
+      - prod
+    Description: Enter profile.
+
+######################################################
+# Mappings:
+######################################################
+Mappings:
+  StackConfig:
+    NameTag:
+      Value: neo-cycle
+
+######################################################
+# Resources
+######################################################
+Resources:
+  S3StatisHostingBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Sub
+        - ${EnvName}.${S3HostingDomainName}
+        - {
+          NameTag: !Ref S3HostingDomainName,
+          EnvName: !Ref EnvName
+        }
+      VersioningConfiguration:
+        Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256  
+      # LifecycleConfiguration:
+      #   Rules:
+      #     - Id: !Join ['-', [!Ref 'BucketNameContents', 'Contents-LifeCycle']]
+      #       Status: Enabled
+      #       # バージョニングされているデータは180日経過したらS3 glacierに移行する
+      #       NoncurrentVersionTransition:
+      #           StorageClass: GLACIER
+      #           TransitionInDays: 180
+      #       # バージョニングされているデータは365日経過したら削除する
+      #       NoncurrentVersionExpirationInDays: 365
+
+  S3LambdaBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Sub
+        - ${NameTag}-${EnvName}-lambda
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
+      VersioningConfiguration:
+        Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256  
+      # LifecycleConfiguration:
+      #   Rules:
+      #     - Id: !Join ['-', [!Ref 'BucketNameContents', 'Contents-LifeCycle']]
+      #       Status: Enabled
+      #       # バージョニングされているデータは180日経過したらS3 glacierに移行する
+      #       NoncurrentVersionTransition:
+      #           StorageClass: GLACIER
+      #           TransitionInDays: 180
+      #       # バージョニングされているデータは365日経過したら削除する
+      #       NoncurrentVersionExpirationInDays: 365


### PR DESCRIPTION
## やったこと
- 複数の環境が構築できるようtemplateファイルを拡張した。

## やってないこと
- 以下は修正していない
### dynamodb
- セッション管理はクライアント側で行うようにする方針なのでもはや修正していない。
### cloudwatch events
- セッション管理はクライアント側で行うようにする方針なので、もはやセッションを張りなおすLambdaは新規環境には不要なので修正していない。

## TODO
- API GatewayはLambdaのARNをimportValueしているので、Lambdaの修正内容によっては、CodeBuildによるLambdaの変更とデッドロックする可能性あり。1templateファイルで管理するようにして、CodeBuildで一緒にデプロイするように修正する。1ファイルが長くなりそうで嫌だなあ。