### PR TITLE
API GatewayとLambdaを同一スタックで管理する

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,23 +13,23 @@ phases:
       - cd ./SessionMaintainer
       - npm install
       - zip -r Deploy.zip ./
-      - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
+      - aws s3 mv ./Deploy.zip s3://neo-cycle-dev-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
       - cd ../ParkingRetriever
       - npm install
       - zip -r Deploy.zip ./
-      - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/ParkingRetriever/Deploy.zip
+      - aws s3 mv ./Deploy.zip s3://neo-cycle-dev-lambda/${CODEBUILD_BUILD_NUMBER}/ParkingRetriever/Deploy.zip
       - cd ../ReservationMaker
       - npm install
       - zip -r Deploy.zip ./
-      - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/ReservationMaker/Deploy.zip
+      - aws s3 mv ./Deploy.zip s3://neo-cycle-dev-lambda/${CODEBUILD_BUILD_NUMBER}/ReservationMaker/Deploy.zip
       - cd ../ReservationCanceller
       - npm install
       - zip -r Deploy.zip ./
-      - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/ReservationCanceller/Deploy.zip
+      - aws s3 mv ./Deploy.zip s3://neo-cycle-dev-lambda/${CODEBUILD_BUILD_NUMBER}/ReservationCanceller/Deploy.zip
       - cd ../StatusChecker
       - npm install
       - zip -r Deploy.zip ./
-      - aws s3 mv ./Deploy.zip s3://neo-cycle-lambda/${CODEBUILD_BUILD_NUMBER}/StatusChecker/Deploy.zip
+      - aws s3 mv ./Deploy.zip s3://neo-cycle-dev-lambda/${CODEBUILD_BUILD_NUMBER}/StatusChecker/Deploy.zip
       - cd ../../neo-cycle-infra
       - aws cloudformation deploy
           --stack-name neo-cycle-${ENVIRONMENT_NAME}-lambda

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,23 +13,23 @@ phases:
       - cd ./SessionMaintainer
       - npm install
       - zip -r Deploy.zip ./
-      - aws s3 mv ./Deploy.zip s3://neo-cycle-dev-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
+      - aws s3 mv ./Deploy.zip s3://neo-cycle-${ENVIRONMENT_NAME}-lambda/${CODEBUILD_BUILD_NUMBER}/SessionMaintainer/Deploy.zip
       - cd ../ParkingRetriever
       - npm install
       - zip -r Deploy.zip ./
-      - aws s3 mv ./Deploy.zip s3://neo-cycle-dev-lambda/${CODEBUILD_BUILD_NUMBER}/ParkingRetriever/Deploy.zip
+      - aws s3 mv ./Deploy.zip s3://neo-cycle-${ENVIRONMENT_NAME}-lambda/${CODEBUILD_BUILD_NUMBER}/ParkingRetriever/Deploy.zip
       - cd ../ReservationMaker
       - npm install
       - zip -r Deploy.zip ./
-      - aws s3 mv ./Deploy.zip s3://neo-cycle-dev-lambda/${CODEBUILD_BUILD_NUMBER}/ReservationMaker/Deploy.zip
+      - aws s3 mv ./Deploy.zip s3://neo-cycle-${ENVIRONMENT_NAME}-lambda/${CODEBUILD_BUILD_NUMBER}/ReservationMaker/Deploy.zip
       - cd ../ReservationCanceller
       - npm install
       - zip -r Deploy.zip ./
-      - aws s3 mv ./Deploy.zip s3://neo-cycle-dev-lambda/${CODEBUILD_BUILD_NUMBER}/ReservationCanceller/Deploy.zip
+      - aws s3 mv ./Deploy.zip s3://neo-cycle-${ENVIRONMENT_NAME}-lambda/${CODEBUILD_BUILD_NUMBER}/ReservationCanceller/Deploy.zip
       - cd ../StatusChecker
       - npm install
       - zip -r Deploy.zip ./
-      - aws s3 mv ./Deploy.zip s3://neo-cycle-dev-lambda/${CODEBUILD_BUILD_NUMBER}/StatusChecker/Deploy.zip
+      - aws s3 mv ./Deploy.zip s3://neo-cycle-${ENVIRONMENT_NAME}-lambda/${CODEBUILD_BUILD_NUMBER}/StatusChecker/Deploy.zip
       - cd ../../neo-cycle-infra
       - aws cloudformation deploy
           --stack-name neo-cycle-${ENVIRONMENT_NAME}-lambda

--- a/neo-cycle-infra/CodePipeline/code-pipeline.yaml
+++ b/neo-cycle-infra/CodePipeline/code-pipeline.yaml
@@ -80,6 +80,7 @@ Resources:
               - "*"
             Action:
               - cloudformation:*
+              - apigateway:*
           - Effect: Allow
             Resource:
               - "*"

--- a/neo-cycle-infra/CodePipeline/code-pipeline.yaml
+++ b/neo-cycle-infra/CodePipeline/code-pipeline.yaml
@@ -31,14 +31,6 @@ Parameters:
     Description: Enter profile.
 
 ######################################################
-# Mappings
-######################################################
-Mappings:
-  StackConfig:
-    NameTag:
-      Value: neo-cycle
-
-######################################################
 # Resources
 ######################################################
 Resources:
@@ -54,18 +46,8 @@ Resources:
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource:
-              - !Sub
-                - arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}-build
-                - {
-                  NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-                  EnvName: !Ref EnvName
-                }
-              - !Sub
-                - arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}-build:*
-                - {
-                  NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-                  EnvName: !Ref EnvName
-                }
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}-${EnvName}-build
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${NameTag}-${EnvName}-build:*
           - Effect: Allow
             Resource:
               - "*"
@@ -94,52 +76,22 @@ Resources:
             Resource:
               # RoleをアタッチするLambdaが増えるごとにここに追加していく
               - !ImportValue
-                Fn::Sub:
-                  - ${NameTag}-${EnvName}-RoleSessionMaintainerArn
-                  - {
-                    NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-                    EnvName: !Ref EnvName
-                  }
+                Fn::Sub: ${NameTag}-${EnvName}-RoleSessionMaintainerArn
               - !ImportValue
-                Fn::Sub:
-                  - ${NameTag}-${EnvName}-RoleParkingRetrieverArn
-                  - {
-                    NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-                    EnvName: !Ref EnvName
-                  }
+                Fn::Sub: ${NameTag}-${EnvName}-RoleParkingRetrieverArn
               - !ImportValue
-                Fn::Sub:
-                  - ${NameTag}-${EnvName}-RoleReservationMakerArn
-                  - {
-                    NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-                    EnvName: !Ref EnvName
-                  }
+                Fn::Sub: ${NameTag}-${EnvName}-RoleReservationMakerArn
               - !ImportValue
-                Fn::Sub:
-                  - ${NameTag}-${EnvName}-RoleReservationCancellerArn
-                  - {
-                    NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-                    EnvName: !Ref EnvName
-                  }
+                Fn::Sub: ${NameTag}-${EnvName}-RoleReservationCancellerArn
               - !ImportValue
-                Fn::Sub:
-                  - ${NameTag}-${EnvName}-RoleStatusCheckerArn
-                  - {
-                    NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-                    EnvName: !Ref EnvName
-                  }
+                Fn::Sub: ${NameTag}-${EnvName}-RoleStatusCheckerArn
             Action:
               - iam:PassRole
 
   RoleCodeBuildService:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub
-        - role-${NameTag}-${EnvName}-codebuild
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      RoleName: !Sub role-${NameTag}-${EnvName}-codebuild
       ManagedPolicyArns:
         - !Ref CodeBuildBasePolicy
       AssumeRolePolicyDocument:
@@ -165,24 +117,14 @@ Resources:
         Type: LINUX_CONTAINER
         Image: aws/codebuild/standard:2.0-1.13.0
       ServiceRole: !GetAtt RoleCodeBuildService.Arn
-      Name: !Sub
-        - ${NameTag}-${EnvName}-build
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      Name: !Sub ${NameTag}-${EnvName}-build
       Source:
         Type: CODEPIPELINE
 
   CodePipelineServiceRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub
-        - role-${NameTag}-${EnvName}-code-pipeline
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      RoleName: !Sub role-${NameTag}-${EnvName}-code-pipeline
       Path: /
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -216,12 +158,7 @@ Resources:
   NeoCyclePipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
-      Name: !Sub
-        - ${NameTag}-${EnvName}-code-pipeline
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      Name: !Sub ${NameTag}-${EnvName}-code-pipeline
       ArtifactStore:
         Type: S3
         Location: codepipeline-ap-northeast-1-299374294168

--- a/neo-cycle-infra/Lambda/lambda.yaml
+++ b/neo-cycle-infra/Lambda/lambda.yaml
@@ -9,20 +9,17 @@ Description: >
 Parameters:
   ObjectKeyPrefix:
     Type: String
+  NameTag:
+    Type: String
+    Default: neo-cycle
+    AllowedValues:
+      - neo-cycle
   EnvName:
     Type: String
     AllowedValues:
       - dev
       - prod
     Description: Enter profile.
-
-######################################################
-# Mappings:
-######################################################
-Mappings:
-  StackConfig:
-    NameTag:
-      Value: neo-cycle
 
 ######################################################
 # Resources
@@ -32,32 +29,13 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: !Sub
-          - ${NameTag}-${EnvName}-lambda
-          - {
-            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-            EnvName: !Ref EnvName
-          }
-        S3Key: !Sub
-          - ${ObjectKeyPrefix}/SessionMaintainer/Deploy.zip
-          - {
-            ObjectKeyPrefix: !Ref ObjectKeyPrefix
-          }
-      FunctionName: !Sub
-        - ${NameTag}-${EnvName}-SessionMaintainer
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+        S3Bucket: !Sub ${NameTag}-${EnvName}-lambda
+        S3Key: !Sub ${ObjectKeyPrefix}/SessionMaintainer/Deploy.zip
+      FunctionName: !Sub ${NameTag}-${EnvName}-SessionMaintainer
       Handler: index.handler
       ReservedConcurrentExecutions: 1
       Role: !ImportValue
-        Fn::Sub:
-          - ${NameTag}-${EnvName}-RoleSessionMaintainerArn
-          - {
-            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-            EnvName: !Ref EnvName
-          }
+        Fn::Sub: ${NameTag}-${EnvName}-RoleSessionMaintainerArn
       Runtime: nodejs12.x
       Timeout: 10
 
@@ -65,35 +43,16 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: !Sub
-          - ${NameTag}-${EnvName}-lambda
-          - {
-            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-            EnvName: !Ref EnvName
-          }
-        S3Key: !Sub
-          - ${ObjectKeyPrefix}/ParkingRetriever/Deploy.zip
-          - {
-            ObjectKeyPrefix: !Ref ObjectKeyPrefix
-          }
+        S3Bucket: !Sub ${NameTag}-${EnvName}-lambda
+        S3Key: !Sub ${ObjectKeyPrefix}/ParkingRetriever/Deploy.zip
       Environment:
         Variables:
           PARKING_IDS: 10124,10077,10507
-      FunctionName: !Sub
-        - ${NameTag}-${EnvName}-ParkingRetriever
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-          }
+      FunctionName: !Sub ${NameTag}-${EnvName}-ParkingRetriever
       Handler: index.handler
       ReservedConcurrentExecutions: 1
       Role: !ImportValue
-        Fn::Sub:
-          - ${NameTag}-${EnvName}-RoleParkingRetrieverArn
-          - {
-            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-            EnvName: !Ref EnvName
-          }
+        Fn::Sub: ${NameTag}-${EnvName}-RoleParkingRetrieverArn
       Runtime: nodejs12.x
       Timeout: 10
 
@@ -101,32 +60,13 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: !Sub
-          - ${NameTag}-${EnvName}-lambda
-          - {
-            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-            EnvName: !Ref EnvName
-          }
-        S3Key: !Sub
-          - ${ObjectKeyPrefix}/ReservationMaker/Deploy.zip
-          - {
-            ObjectKeyPrefix: !Ref ObjectKeyPrefix
-          }
-      FunctionName: !Sub
-        - ${NameTag}-${EnvName}-ReservationMaker
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+        S3Bucket: !Sub ${NameTag}-${EnvName}-lambda
+        S3Key: !Sub ${ObjectKeyPrefix}/ReservationMaker/Deploy.zip
+      FunctionName: !Sub ${NameTag}-${EnvName}-ReservationMaker
       Handler: index.handler
       ReservedConcurrentExecutions: 1
       Role: !ImportValue
-        Fn::Sub:
-          - ${NameTag}-${EnvName}-RoleReservationMakerArn
-          - {
-            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-            EnvName: !Ref EnvName
-          }
+        Fn::Sub: ${NameTag}-${EnvName}-RoleReservationMakerArn
       Runtime: nodejs12.x
       Timeout: 10
 
@@ -134,32 +74,13 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: !Sub
-          - ${NameTag}-${EnvName}-lambda
-          - {
-            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-            EnvName: !Ref EnvName
-          }
-        S3Key: !Sub
-          - ${ObjectKeyPrefix}/ReservationCanceller/Deploy.zip
-          - {
-            ObjectKeyPrefix: !Ref ObjectKeyPrefix
-          }
-      FunctionName: !Sub
-        - ${NameTag}-${EnvName}-ReservationCanceller
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+        S3Bucket: !Sub ${NameTag}-${EnvName}-lambda
+        S3Key: !Sub ${ObjectKeyPrefix}/ReservationCanceller/Deploy.zip
+      FunctionName: !Sub ${NameTag}-${EnvName}-ReservationCanceller
       Handler: index.handler
       ReservedConcurrentExecutions: 1
       Role: !ImportValue
-        Fn::Sub:
-          - ${NameTag}-${EnvName}-RoleReservationCancellerArn
-          - {
-            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-            EnvName: !Ref EnvName
-          }
+        Fn::Sub: ${NameTag}-${EnvName}-RoleReservationCancellerArn
       Runtime: nodejs12.x
       Timeout: 10
 
@@ -167,34 +88,339 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: !Sub
-          - ${NameTag}-${EnvName}-lambda
-          - {
-            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-            EnvName: !Ref EnvName
-          }
-        S3Key: !Sub
-          - ${ObjectKeyPrefix}/StatusChecker/Deploy.zip
-          - {
-            ObjectKeyPrefix: !Ref ObjectKeyPrefix
-          }
-      FunctionName: !Sub
-        - ${NameTag}-${EnvName}-StatusChecker
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+        S3Bucket: !Sub ${NameTag}-${EnvName}-lambda
+        S3Key: !Sub ${ObjectKeyPrefix}/StatusChecker/Deploy.zip
+      FunctionName: !Sub ${NameTag}-${EnvName}-StatusChecker
       Handler: index.handler
       ReservedConcurrentExecutions: 1
       Role: !ImportValue
-        Fn::Sub:
-          - ${NameTag}-${EnvName}-RoleStatusCheckerArn
-          - {
-            NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-            EnvName: !Ref EnvName
-          }
+        Fn::Sub: ${NameTag}-${EnvName}-RoleStatusCheckerArn
       Runtime: nodejs12.x
       Timeout: 10
+
+  ######################################################
+  # Rest API
+  ######################################################
+  NeoCycleRestAPI:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: !Sub  ${NameTag}-${EnvName}-api-gateway
+      EndpointConfiguration:
+        Types:
+          - EDGE
+
+
+  ######################################################
+  # Parkings
+  #   - Resource
+  #     - path: /parkings
+  #   - Method
+  #     - POST
+  #     - OPTION(for enable CORS)
+  #   - Lambda Permission
+  ######################################################
+  ParkingsResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref NeoCycleRestAPI
+      ParentId: !GetAtt
+        - NeoCycleRestAPI
+        - RootResourceId
+      PathPart: parkings
+
+  ParkingsPostMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      HttpMethod: POST
+      ResourceId: !Ref ParkingsResource
+      RestApiId: !Ref NeoCycleRestAPI
+      MethodResponses: 
+        - StatusCode: 200
+          ResponseParameters:
+            "method.response.header.Access-Control-Allow-Origin" : true
+      Integration:
+        Type: AWS
+        Uri: !Sub arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaParkingRetriever.Arn}/invocations
+        IntegrationHttpMethod: POST
+        IntegrationResponses:
+          - StatusCode: 200
+            ResponseParameters:
+              'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
+    DependsOn: LambdaParkingsRegistererPermission
+
+  ParkingsOptionsMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      RestApiId:
+        Ref: NeoCycleRestAPI
+      ResourceId:
+        Ref: ParkingsResource
+      HttpMethod: OPTIONS
+      Integration:
+        IntegrationResponses:
+        - StatusCode: 200
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+            method.response.header.Access-Control-Allow-Methods: "'POST,OPTIONS'"
+            method.response.header.Access-Control-Allow-Origin: "'*'"
+          ResponseTemplates:
+            application/json: ''
+        PassthroughBehavior: WHEN_NO_MATCH
+        RequestTemplates:
+          application/json: '{"statusCode": 200}'
+        Type: MOCK
+      MethodResponses:
+      - StatusCode: 200
+        ResponseModels:
+          application/json: 'Empty'
+        ResponseParameters:
+          method.response.header.Access-Control-Allow-Headers: false
+          method.response.header.Access-Control-Allow-Methods: false
+          method.response.header.Access-Control-Allow-Origin: false
+    DependsOn: ParkingsResource
+
+  LambdaParkingsRegistererPermission:
+    Type: AWS::Lambda::Permission
+    Properties: 
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref LambdaParkingRetriever
+      Principal: apigateway.amazonaws.com
+
+  ######################################################
+  # Reservation
+  #   - Resource
+  #     - path: /reservation
+  #   - Method
+  #     - POST
+  #     - OPTION(for enable CORS)
+  #   - Lambda Permission
+  ######################################################
+  ReservationResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref NeoCycleRestAPI
+      ParentId: !GetAtt
+        - NeoCycleRestAPI
+        - RootResourceId
+      PathPart: reservation
+
+  ReservationPostMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      HttpMethod: POST
+      ResourceId: !Ref ReservationResource
+      RestApiId: !Ref NeoCycleRestAPI
+      MethodResponses: 
+        - StatusCode: 200
+          ResponseParameters:
+            "method.response.header.Access-Control-Allow-Origin" : true
+      Integration:
+        Type: AWS
+        Uri: !Sub arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaReservationMaker.Arn}/invocations
+        IntegrationHttpMethod: POST
+        IntegrationResponses:
+          - StatusCode: 200
+            ResponseParameters:
+              'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
+    DependsOn: LambdaReservationMakerPermission
+
+  ReservationOptionsMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      RestApiId:
+        Ref: NeoCycleRestAPI
+      ResourceId:
+        Ref: ReservationResource
+      HttpMethod: OPTIONS
+      Integration:
+        IntegrationResponses:
+        - StatusCode: 200
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+            method.response.header.Access-Control-Allow-Methods: "'POST,OPTIONS'"
+            method.response.header.Access-Control-Allow-Origin: "'*'"
+          ResponseTemplates:
+            application/json: ''
+        PassthroughBehavior: WHEN_NO_MATCH
+        RequestTemplates:
+          application/json: '{"statusCode": 200}'
+        Type: MOCK
+      MethodResponses:
+      - StatusCode: 200
+        ResponseModels:
+          application/json: 'Empty'
+        ResponseParameters:
+          method.response.header.Access-Control-Allow-Headers: false
+          method.response.header.Access-Control-Allow-Methods: false
+          method.response.header.Access-Control-Allow-Origin: false
+    DependsOn: ReservationResource
+
+  LambdaReservationMakerPermission:
+    Type: AWS::Lambda::Permission
+    Properties: 
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref LambdaReservationMaker
+      Principal: apigateway.amazonaws.com
+
+  ######################################################
+  # Cancellation
+  #   - Resource
+  #     - path: /cancellation
+  #   - Method
+  #     - POST
+  #     - OPTION(for enable CORS)
+  #   - Lambda Permission
+  ######################################################
+  CancellationResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref NeoCycleRestAPI
+      ParentId: !GetAtt
+        - NeoCycleRestAPI
+        - RootResourceId
+      PathPart: cancellation
+
+  CancellationPostMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      HttpMethod: POST
+      ResourceId: !Ref CancellationResource
+      RestApiId: !Ref NeoCycleRestAPI
+      MethodResponses: 
+        - StatusCode: 200
+          ResponseParameters:
+            "method.response.header.Access-Control-Allow-Origin" : true
+      Integration:
+        Type: AWS
+        Uri: !Sub arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaReservationCanceller.Arn}/invocations
+        IntegrationHttpMethod: POST
+        IntegrationResponses:
+          - StatusCode: 200
+            ResponseParameters:
+              'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
+    DependsOn: LambdaReservationCancellerPermission
+
+  CancellationOptionsMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      RestApiId:
+        Ref: NeoCycleRestAPI
+      ResourceId:
+        Ref: CancellationResource
+      HttpMethod: OPTIONS
+      Integration:
+        IntegrationResponses:
+        - StatusCode: 200
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+            method.response.header.Access-Control-Allow-Methods: "'POST,OPTIONS'"
+            method.response.header.Access-Control-Allow-Origin: "'*'"
+          ResponseTemplates:
+            application/json: ''
+        PassthroughBehavior: WHEN_NO_MATCH
+        RequestTemplates:
+          application/json: '{"statusCode": 200}'
+        Type: MOCK
+      MethodResponses:
+      - StatusCode: 200
+        ResponseModels:
+          application/json: 'Empty'
+        ResponseParameters:
+          method.response.header.Access-Control-Allow-Headers: false
+          method.response.header.Access-Control-Allow-Methods: false
+          method.response.header.Access-Control-Allow-Origin: false
+    DependsOn: CancellationResource
+
+  LambdaReservationCancellerPermission:
+    Type: AWS::Lambda::Permission
+    Properties: 
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref LambdaReservationCanceller
+      Principal: apigateway.amazonaws.com
+
+  ######################################################
+  # Status
+  #   - Resource
+  #     - path: /status
+  #   - Method
+  #     - POST
+  #     - OPTION(for enable CORS)
+  #   - Lambda Permission
+  ######################################################
+  StatusResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref NeoCycleRestAPI
+      ParentId: !GetAtt
+        - NeoCycleRestAPI
+        - RootResourceId
+      PathPart: status
+
+  StatusPostMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      HttpMethod: POST
+      ResourceId: !Ref StatusResource
+      RestApiId: !Ref NeoCycleRestAPI
+      MethodResponses: 
+        - StatusCode: 200
+          ResponseParameters:
+            "method.response.header.Access-Control-Allow-Origin" : true
+      Integration:
+        Type: AWS
+        Uri: !Sub arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaStatusChecker.Arn}/invocations
+        IntegrationHttpMethod: POST
+        IntegrationResponses:
+          - StatusCode: 200
+            ResponseParameters:
+              'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
+    DependsOn: LambdaStatusCheckerPermission
+
+  StatusOptionsMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      RestApiId:
+        Ref: NeoCycleRestAPI
+      ResourceId:
+        Ref: StatusResource
+      HttpMethod: OPTIONS
+      Integration:
+        IntegrationResponses:
+        - StatusCode: 200
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+            method.response.header.Access-Control-Allow-Methods: "'POST,OPTIONS'"
+            method.response.header.Access-Control-Allow-Origin: "'*'"
+          ResponseTemplates:
+            application/json: ''
+        PassthroughBehavior: WHEN_NO_MATCH
+        RequestTemplates:
+          application/json: '{"statusCode": 200}'
+        Type: MOCK
+      MethodResponses:
+      - StatusCode: 200
+        ResponseModels:
+          application/json: 'Empty'
+        ResponseParameters:
+          method.response.header.Access-Control-Allow-Headers: false
+          method.response.header.Access-Control-Allow-Methods: false
+          method.response.header.Access-Control-Allow-Origin: false
+    DependsOn: StatusResource
+
+  LambdaStatusCheckerPermission:
+    Type: AWS::Lambda::Permission
+    Properties: 
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref LambdaStatusChecker
+      Principal: apigateway.amazonaws.com
 
 #################################
 # Outputs
@@ -203,90 +429,40 @@ Outputs:
   LambdaSessionMaintainerArn:
     Value: !GetAtt LambdaSessionMaintainer.Arn
     Export:
-      Name: !Sub
-        - ${NameTag}-${EnvName}-LambdaSessionMaintainerArn
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      Name: !Sub ${NameTag}-${EnvName}-LambdaSessionMaintainerArn
   LambdaSessionMaintainerFunctionName:
     Value: !Ref LambdaSessionMaintainer
     Export:
-      Name: !Sub
-        - ${NameTag}-${EnvName}-LambdaSessionMaintainerFunctionName
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      Name: !Sub ${NameTag}-${EnvName}-LambdaSessionMaintainerFunctionName
   LambdaParkingRetrieverArn:
     Value: !GetAtt LambdaParkingRetriever.Arn
     Export:
-      Name: !Sub
-        - ${NameTag}-${EnvName}-LambdaParkingRetrieverArn
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      Name: !Sub ${NameTag}-${EnvName}-LambdaParkingRetrieverArn
   LambdaParkingRetrieverFunctionName:
     Value: !Ref LambdaParkingRetriever
     Export:
-      Name: !Sub
-        - ${NameTag}-${EnvName}-LambdaParkingRetrieverFunctionName
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      Name: !Sub ${NameTag}-${EnvName}-LambdaParkingRetrieverFunctionName
   LambdaReservationMakerArn:
     Value: !GetAtt LambdaReservationMaker.Arn
     Export:
-      Name: !Sub
-        - ${NameTag}-${EnvName}-LambdaReservationMakerArn
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      Name: !Sub ${NameTag}-${EnvName}-LambdaReservationMakerArn
   LambdaReservationMakerFunctionName:
     Value: !Ref LambdaReservationMaker
     Export:
-      Name: !Sub
-        - ${NameTag}-${EnvName}-LambdaReservationMakerFunctionName
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      Name: !Sub ${NameTag}-${EnvName}-LambdaReservationMakerFunctionName
   LambdaReservationCancellerArn:
     Value: !GetAtt LambdaReservationCanceller.Arn
     Export:
-      Name: !Sub
-        - ${NameTag}-${EnvName}-LambdaReservationCancellerArn
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      Name: !Sub ${NameTag}-${EnvName}-LambdaReservationCancellerArn
   LambdaReservationCancellerFunctionName:
     Value: !Ref LambdaReservationCanceller
     Export:
-      Name: !Sub
-        - ${NameTag}-${EnvName}-LambdaReservationCancellerFunctionName
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      Name: !Sub ${NameTag}-${EnvName}-LambdaReservationCancellerFunctionName
   LambdaStatusCheckerArn:
     Value: !GetAtt LambdaStatusChecker.Arn
     Export:
-      Name: !Sub
-        - ${NameTag}-${EnvName}-LambdaStatusCheckerArn
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      Name: !Sub ${NameTag}-${EnvName}-LambdaStatusCheckerArn
   LambdaStatusCheckerName:
     Value: !Ref LambdaStatusChecker
     Export:
-      Name: !Sub
-        - ${NameTag}-${EnvName}-LambdaStatusCheckerFunctionName
-        - {
-          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
-          EnvName: !Ref EnvName
-        }
+      Name: !Sub ${NameTag}-${EnvName}-LambdaStatusCheckerFunctionName


### PR DESCRIPTION
## やったこと
- API GatewayとLambdaを同一テンプレートで作成するようにした。またそれに伴うCICDの改善をした。

## 背景
- API GatewayとLambdaをそれぞれ別スタックで管理しようとすると、API GatewayはLambdaの作成に依存するので前者で後者の情報をImportValueで取得することになり、それぞれの修正時にデッドロックがかかる可能性がある。そのため同一スタックで管理し、柔軟にAPI開発ができるようにした。
 
## ハマったポイント
- 今回の修正とは関係ないが、buildspec.ymlでLambdaのモジュール取得元のS3バケット名を指定しているのを修正していなかったので、今回ビルドが失敗した。複数環境に対応できるよう、環境変数でカバーするようにしています。

## 改善点
- template長すぎる。