### PR TITLE
API GatewayでLambdaのプロキシ統合を採用

### DIFF
--- a/neo-cycle-client/src/api/cycle-management.js
+++ b/neo-cycle-client/src/api/cycle-management.js
@@ -4,20 +4,19 @@ const url = 'https://zn2vxjwu4d.execute-api.ap-northeast-1.amazonaws.com/dev';
 
 export async function retrieveParkingList() {
   const res = await axios.post(url + '/parkings');
-  return JSON.parse(res.data.body)
+  return res.data
 }
-
 export async function checkStatus() {
   const res = await axios.post(url + '/status');
-  return JSON.parse(res.data.body)
+  return res.data
 }
 
 export async function makeReservation(cycle) {
   const res = await axios.post(url + '/reservation', cycle);
-  return JSON.parse(res.data.body)
+  return res.data
 }
 
 export async function cancelReservation() {
   const res = await axios.post(url + '/cancellation');
-  return JSON.parse(res.data.body)
+  return res.data
 }

--- a/neo-cycle-client/src/api/cycle-management.js
+++ b/neo-cycle-client/src/api/cycle-management.js
@@ -4,20 +4,20 @@ const url = 'https://zn2vxjwu4d.execute-api.ap-northeast-1.amazonaws.com/dev';
 
 export async function retrieveParkingList() {
   const res = await axios.post(url + '/parkings');
-  return res.data.body
+  return JSON.parse(res.data.body)
 }
 
 export async function checkStatus() {
   const res = await axios.post(url + '/status');
-  return res.data.body
+  return JSON.parse(res.data.body)
 }
 
 export async function makeReservation(cycle) {
   const res = await axios.post(url + '/reservation', cycle);
-  return res.data.body
+  return JSON.parse(res.data.body)
 }
 
 export async function cancelReservation() {
   const res = await axios.post(url + '/cancellation');
-  return res.data.body
+  return JSON.parse(res.data.body)
 }

--- a/neo-cycle-infra/Lambda/lambda.yaml
+++ b/neo-cycle-infra/Lambda/lambda.yaml
@@ -139,12 +139,18 @@ Resources:
         - StatusCode: 200
           ResponseParameters:
             "method.response.header.Access-Control-Allow-Origin" : true
+        - StatusCode: 440
+          ResponseParameters:
+            "method.response.header.Access-Control-Allow-Origin" : true            
       Integration:
         Type: AWS
         Uri: !Sub arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaParkingRetriever.Arn}/invocations
         IntegrationHttpMethod: POST
         IntegrationResponses:
           - StatusCode: 200
+            ResponseParameters:
+              'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
+          - StatusCode: 440
             ResponseParameters:
               'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
     DependsOn: LambdaParkingsRegistererPermission
@@ -217,12 +223,18 @@ Resources:
         - StatusCode: 200
           ResponseParameters:
             "method.response.header.Access-Control-Allow-Origin" : true
+        - StatusCode: 440
+          ResponseParameters:
+            "method.response.header.Access-Control-Allow-Origin" : true
       Integration:
         Type: AWS
         Uri: !Sub arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaReservationMaker.Arn}/invocations
         IntegrationHttpMethod: POST
         IntegrationResponses:
           - StatusCode: 200
+            ResponseParameters:
+              'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
+          - StatusCode: 440
             ResponseParameters:
               'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
     DependsOn: LambdaReservationMakerPermission
@@ -295,12 +307,18 @@ Resources:
         - StatusCode: 200
           ResponseParameters:
             "method.response.header.Access-Control-Allow-Origin" : true
+        - StatusCode: 440
+          ResponseParameters:
+            "method.response.header.Access-Control-Allow-Origin" : true
       Integration:
         Type: AWS
         Uri: !Sub arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaReservationCanceller.Arn}/invocations
         IntegrationHttpMethod: POST
         IntegrationResponses:
           - StatusCode: 200
+            ResponseParameters:
+              'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
+          - StatusCode: 440
             ResponseParameters:
               'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
     DependsOn: LambdaReservationCancellerPermission
@@ -373,12 +391,18 @@ Resources:
         - StatusCode: 200
           ResponseParameters:
             "method.response.header.Access-Control-Allow-Origin" : true
+        - StatusCode: 440
+          ResponseParameters:
+            "method.response.header.Access-Control-Allow-Origin" : true
       Integration:
         Type: AWS
         Uri: !Sub arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaStatusChecker.Arn}/invocations
         IntegrationHttpMethod: POST
         IntegrationResponses:
           - StatusCode: 200
+            ResponseParameters:
+              'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
+          - StatusCode: 440
             ResponseParameters:
               'method.response.header.Access-Control-Allow-Origin' : "'*'" # 中身を一重引用符で囲う
     DependsOn: LambdaStatusCheckerPermission

--- a/neo-cycle-infra/Lambda/lambda.yaml
+++ b/neo-cycle-infra/Lambda/lambda.yaml
@@ -143,7 +143,7 @@ Resources:
           ResponseParameters:
             "method.response.header.Access-Control-Allow-Origin" : true            
       Integration:
-        Type: AWS
+        Type: AWS_PROXY
         Uri: !Sub arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaParkingRetriever.Arn}/invocations
         IntegrationHttpMethod: POST
         IntegrationResponses:

--- a/neo-cycle-infra/Lambda/lambda.yaml
+++ b/neo-cycle-infra/Lambda/lambda.yaml
@@ -227,7 +227,7 @@ Resources:
           ResponseParameters:
             "method.response.header.Access-Control-Allow-Origin" : true
       Integration:
-        Type: AWS
+        Type: AWS_PROXY
         Uri: !Sub arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaReservationMaker.Arn}/invocations
         IntegrationHttpMethod: POST
         IntegrationResponses:
@@ -311,7 +311,7 @@ Resources:
           ResponseParameters:
             "method.response.header.Access-Control-Allow-Origin" : true
       Integration:
-        Type: AWS
+        Type: AWS_PROXY
         Uri: !Sub arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaReservationCanceller.Arn}/invocations
         IntegrationHttpMethod: POST
         IntegrationResponses:
@@ -395,7 +395,7 @@ Resources:
           ResponseParameters:
             "method.response.header.Access-Control-Allow-Origin" : true
       Integration:
-        Type: AWS
+        Type: AWS_PROXY
         Uri: !Sub arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/${LambdaStatusChecker.Arn}/invocations
         IntegrationHttpMethod: POST
         IntegrationResponses:

--- a/neo-cycle-lambda/ParkingRetriever/index.js
+++ b/neo-cycle-lambda/ParkingRetriever/index.js
@@ -25,12 +25,13 @@ async function main(event, context) {
   const parkingList = await retrieveParkingList(memberId, sessionId);
   const response = {
     statusCode: 200,
-    body: {
+    body: JSON.stringify({
       parkingList
-    },
+    }),
     headers: {
         "Access-Control-Allow-Origin": '*'
-    }
+    },
+    isBase64Encoded: false
   };
   return response;
 }

--- a/neo-cycle-lambda/ReservationCanceller/index.js
+++ b/neo-cycle-lambda/ReservationCanceller/index.js
@@ -24,10 +24,11 @@ async function main(event, context) {
   await cancelReservation(memberId, sessionId, 27901);
   const response = {
     statusCode: 200,
-    body: {},
+    body: "",
     headers: {
         "Access-Control-Allow-Origin": '*'
-    }
+    },
+    isBase64Encoded: false
   };
   return response;
 }

--- a/neo-cycle-lambda/ReservationMaker/index.js
+++ b/neo-cycle-lambda/ReservationMaker/index.js
@@ -24,13 +24,14 @@ async function main(event, context) {
   if (event.CycleName !== cycleName) {throw new Error("unexpected error occurred.")}
   const response = {
     statusCode: 200,
-    body: {
+    body: JSON.stringify({
       cycleName,
       cyclePasscode
-    },
+    }),
     headers: {
         "Access-Control-Allow-Origin": '*'
-    }
+    },
+    isBase64Encoded: false
   };
   return response;
 }

--- a/neo-cycle-lambda/StatusChecker/index.js
+++ b/neo-cycle-lambda/StatusChecker/index.js
@@ -22,10 +22,11 @@ async function main(event, context) {
   const sessionId = await getSessionId(memberId);
   const response = {
     statusCode: 200,
-    body: await checkStatus(memberId, sessionId),
+    body: JSON.stringify(await checkStatus(memberId, sessionId)),
     headers: {
         "Access-Control-Allow-Origin": '*'
-    }
+    },
+    isBase64Encoded: false
   };
   return response;
 }


### PR DESCRIPTION
## やったこと
- Lambdaのプロキシ統合を有効化して、LambdaでHTTPステータスをハンドリングできるようにした。
- 上記に伴う、LambdaとClientのインターフェースの修正
   - Lambdaのレスポンスのbodyはstringにしなきゃいけない
   - レスポンスにはbodyだけがparseされて返却される

## やっていないこと
- ClientでのHTTPステータスのハンドリング