### PR TITLE
ポート照会APIの取得対象をDynamoDBから取得できるようにした＆サインアップ時にユーザ情報をDynamoにput

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -38,6 +38,10 @@ phases:
       - npm install
       - zip -r Deploy.zip ./
       - aws s3 mv ./Deploy.zip s3://neo-cycle-${ENVIRONMENT_NAME}-lambda/${CODEBUILD_BUILD_NUMBER}/ParkingNearbyRetriever/Deploy.zip
+      - cd ../UserInitializer
+      - npm install
+      - zip -r Deploy.zip ./
+      - aws s3 mv ./Deploy.zip s3://neo-cycle-${ENVIRONMENT_NAME}-lambda/${CODEBUILD_BUILD_NUMBER}/UserInitializer/Deploy.zip
       - cd ../../neo-cycle-infra
       - aws cloudformation deploy
           --stack-name neo-cycle-${ENVIRONMENT_NAME}-lambda

--- a/neo-cycle-infra/CodePipeline/code-pipeline.yaml
+++ b/neo-cycle-infra/CodePipeline/code-pipeline.yaml
@@ -87,6 +87,8 @@ Resources:
                 Fn::Sub: ${NameTag}-${EnvName}-RoleSessionCreatorArn
               - !ImportValue
                 Fn::Sub: ${NameTag}-${EnvName}-RoleParkingNearbyRetrieverArn
+              - !ImportValue
+                Fn::Sub: ${NameTag}-${EnvName}-RoleUserInitializerArn
             Action:
               - iam:PassRole
 

--- a/neo-cycle-infra/Cognito/1.cognito-user-pool.yml
+++ b/neo-cycle-infra/Cognito/1.cognito-user-pool.yml
@@ -13,6 +13,11 @@ Parameters:
       - dev
       - prod
     Description: Enter profile.
+  NameTag:
+    Type: String
+    Default: neo-cycle
+    AllowedValues:
+      - neo-cycle
 
 ######################################################
 # Mappings
@@ -50,6 +55,9 @@ Resources:
           TemporaryPasswordValidityDays: 7
       AutoVerifiedAttributes:
         - email
+      LambdaConfig:
+        PostConfirmation: !ImportValue
+          Fn::Sub: ${NameTag}-${EnvName}-LambdaUserInitializerArn
 
   NeoCycleUserPoolClient:
     Type: AWS::Cognito::UserPoolClient

--- a/neo-cycle-infra/Cognito/3.cognito-lambda-permission.yaml
+++ b/neo-cycle-infra/Cognito/3.cognito-lambda-permission.yaml
@@ -1,0 +1,34 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  Cognito User Pool
+
+######################################################
+# Parameters:
+######################################################
+Parameters:
+  EnvName:
+    Type: String
+    AllowedValues:
+      - dev
+      - prod
+    Description: Enter profile.
+  NameTag:
+    Type: String
+    Default: neo-cycle
+    AllowedValues:
+      - neo-cycle
+
+######################################################
+# Resources
+######################################################
+Resources:
+  LambdaPostConfirmationPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !ImportValue
+        Fn::Sub: ${NameTag}-${EnvName}-LambdaUserInitializerName
+      Principal: cognito-idp.amazonaws.com
+      SourceArn: !ImportValue
+        Fn::Sub: ${NameTag}-${EnvName}-UserPoolArn

--- a/neo-cycle-infra/IAM/iam.yaml
+++ b/neo-cycle-infra/IAM/iam.yaml
@@ -218,7 +218,26 @@ Resources:
             Action: sts:AssumeRole
             Principal:
               Service: lambda.amazonaws.com
-              
+
+  RoleUserInitializer:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub
+        - ${NameTag}-${EnvName}-user-initializer-role
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
+      ManagedPolicyArns:
+        - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
+        - !Ref NeoCycleUserTablePutItemPolicy
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: lambda.amazonaws.com              
 #################################
 # Outputs
 #################################
@@ -288,6 +307,16 @@ Outputs:
     Export:
       Name: !Sub
         - ${NameTag}-${EnvName}-RoleParkingNearbyRetrieverArn
+        - {
+          NameTag: !FindInMap [ StackConfig, NameTag, Value ],
+          EnvName: !Ref EnvName
+        }
+
+  RoleUserInitializerArn:
+    Value: !GetAtt RoleUserInitializer.Arn
+    Export:
+      Name: !Sub
+        - ${NameTag}-${EnvName}-RoleUserInitializerArn
         - {
           NameTag: !FindInMap [ StackConfig, NameTag, Value ],
           EnvName: !Ref EnvName

--- a/neo-cycle-infra/IAM/iam.yaml
+++ b/neo-cycle-infra/IAM/iam.yaml
@@ -10,7 +10,11 @@ Parameters:
       - dev
       - prod
     Description: Enter profile.
-
+  NameTag:
+    Type: String
+    Default: neo-cycle
+    AllowedValues:
+      - neo-cycle
 ######################################################
 # Mappings:
 ######################################################
@@ -28,10 +32,10 @@ Resources:
   #-----------------------
   # ポリシー作成
   #-----------------------
-  NeoCycleSessionTablePutItemPolicy:
+  NeoCycleUserTablePutItemPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
-      Description: authorize to put item into session dynamodb 
+      Description: authorize to put item into user dynamodb 
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -39,12 +43,12 @@ Resources:
             Action:
               - dynamodb:PutItem
             Resource:
-              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/neo-cycle-SESSION"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${NameTag}-${EnvName}-USER"
 
-  NeoCycleSessionTableGetItemPolicy:
+  NeoCycleUserTableGetItemPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
-      Description: authorize to get item from session dynamodb 
+      Description: authorize to get item from user dynamodb 
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -52,7 +56,7 @@ Resources:
             Action:
               - dynamodb:GetItem
             Resource:
-              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/neo-cycle-SESSION"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${NameTag}-${EnvName}-USER"
 
   NeoCycleGetParameterPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -65,8 +69,6 @@ Resources:
             Action:
               - ssm:getParameter
             Resource:
-              - arn:aws:ssm:ap-northeast-1:010660485109:parameter/neo-cycle/memberId
-              - arn:aws:ssm:ap-northeast-1:010660485109:parameter/neo-cycle/password
               - arn:aws:ssm:ap-northeast-1:010660485109:parameter/neo-cycle/php-url
 
   #-----------------------
@@ -83,7 +85,7 @@ Resources:
         }
       ManagedPolicyArns:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
-        - !Ref NeoCycleSessionTablePutItemPolicy
+        - !Ref NeoCycleUserTablePutItemPolicy
         - !Ref NeoCycleGetParameterPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -104,7 +106,7 @@ Resources:
         }
       ManagedPolicyArns:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
-        - !Ref NeoCycleSessionTableGetItemPolicy
+        - !Ref NeoCycleUserTableGetItemPolicy
         - !Ref NeoCycleGetParameterPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -125,7 +127,7 @@ Resources:
         }
       ManagedPolicyArns:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
-        - !Ref NeoCycleSessionTableGetItemPolicy
+        - !Ref NeoCycleUserTableGetItemPolicy
         - !Ref NeoCycleGetParameterPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -146,7 +148,7 @@ Resources:
         }
       ManagedPolicyArns:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
-        - !Ref NeoCycleSessionTableGetItemPolicy
+        - !Ref NeoCycleUserTableGetItemPolicy
         - !Ref NeoCycleGetParameterPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -167,7 +169,7 @@ Resources:
         }
       ManagedPolicyArns:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
-        - !Ref NeoCycleSessionTableGetItemPolicy
+        - !Ref NeoCycleUserTableGetItemPolicy
         - !Ref NeoCycleGetParameterPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/neo-cycle-infra/Lambda/lambda.yaml
+++ b/neo-cycle-infra/Lambda/lambda.yaml
@@ -48,7 +48,6 @@ Resources:
         S3Key: !Sub ${ObjectKeyPrefix}/ParkingRetriever/Deploy.zip
       Environment:
         Variables:
-          PARKING_IDS: 10124,10077,10507
           ENV_NAME: !Ref EnvName
       FunctionName: !Sub ${NameTag}-${EnvName}-ParkingRetriever
       Handler: index.handler

--- a/neo-cycle-infra/Lambda/lambda.yaml
+++ b/neo-cycle-infra/Lambda/lambda.yaml
@@ -134,6 +134,24 @@ Resources:
       Timeout: 10
       ReservedConcurrentExecutions: 10
       MemorySize: 3008
+
+  LambdaUserInitializer:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: !Sub ${NameTag}-${EnvName}-lambda
+        S3Key: !Sub ${ObjectKeyPrefix}/UserInitializer/Deploy.zip
+      Environment:
+        Variables:
+          ENV_NAME: !Ref EnvName
+      FunctionName: !Sub ${NameTag}-${EnvName}-UserInitializer
+      Handler: index.handler
+      ReservedConcurrentExecutions: 1
+      Role: !ImportValue
+        Fn::Sub: ${NameTag}-${EnvName}-RoleUserInitializerArn
+      Runtime: nodejs12.x
+      Timeout: 10
+      ReservedConcurrentExecutions: 10
   ######################################################
   # Rest API
   ######################################################
@@ -714,3 +732,11 @@ Outputs:
     Value: !Ref LambdaParkingNearbyRetriever
     Export:
       Name: !Sub ${NameTag}-${EnvName}-LambdaParkingNearbyRetrieverName
+  LambdaUserInitializerArn:
+    Value: !GetAtt LambdaUserInitializer.Arn
+    Export:
+      Name: !Sub ${NameTag}-${EnvName}-LambdaUserInitializerArn
+  LambdaUserInitializerName:
+    Value: !Ref LambdaUserInitializer
+    Export:
+      Name: !Sub ${NameTag}-${EnvName}-LambdaUserInitializerName

--- a/neo-cycle-infra/Lambda/lambda.yaml
+++ b/neo-cycle-infra/Lambda/lambda.yaml
@@ -49,6 +49,7 @@ Resources:
       Environment:
         Variables:
           PARKING_IDS: 10124,10077,10507
+          ENV_NAME: !Ref EnvName
       FunctionName: !Sub ${NameTag}-${EnvName}-ParkingRetriever
       Handler: index.handler
       ReservedConcurrentExecutions: 1

--- a/neo-cycle-infra/Middleware/dynamodb.yaml
+++ b/neo-cycle-infra/Middleware/dynamodb.yaml
@@ -1,17 +1,32 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  FtfWebManagementRecorder
-  and FtfWebManagement DynamoDB setup
+  DynamoDB setup
+
+######################################################
+# Parameters:
+######################################################
+Parameters:
+  NameTag:
+    Type: String
+    Default: neo-cycle
+    AllowedValues:
+      - neo-cycle
+  EnvName:
+    Type: String
+    AllowedValues:
+      - dev
+      - prod
+    Description: Enter profile.
 
 ######################################################
 # Resources
 ######################################################
 Resources:
   #----------------------------------------------
-  # SESSION
+  # USER
   #----------------------------------------------
-  FOOD:
+  USER:
     Type: AWS::DynamoDB::Table
     Properties:
       KeySchema:
@@ -20,7 +35,7 @@ Resources:
       AttributeDefinitions:
         - AttributeName: memberId
           AttributeType: S
-      TableName: neo-cycle-SESSION
+      TableName: !Sub ${NameTag}-${EnvName}-USER
       BillingMode: PAY_PER_REQUEST
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true

--- a/neo-cycle-lambda/ParkingRetriever/index.js
+++ b/neo-cycle-lambda/ParkingRetriever/index.js
@@ -133,11 +133,13 @@ async function retrieveParkingList(memberId, sessionId, savedParkingList) {
 async function retrievedSavedParkingList(memberId) {
   const params = {
     TableName: userTableName,
-    Key: memberId
+    Key: {
+      memberId: memberId
+    }
   }
   try {
     const result = await docClient.get(params).promise();
-    return result.Item.favoriteParkingList;
+    return result.Item ? result.Item.favoriteParkingList : []; // ユーザ情報登録APIができたら空配列は返さない
   }
   catch (error) {
     throw error

--- a/neo-cycle-lambda/ParkingRetriever/index.js
+++ b/neo-cycle-lambda/ParkingRetriever/index.js
@@ -9,7 +9,6 @@ const cheerio = require('cheerio');
 const envName = process.env.ENV_NAME;
 const userTableName = `neo-cycle-${envName}-USER`;
 const getInfoNum = 300;
-const parkingIdList = process.env['PARKING_IDS'].split(',');
 
 exports.handler = async (event, context) => {
   if (event.warmup) {

--- a/neo-cycle-lambda/UserInitializer/index.js
+++ b/neo-cycle-lambda/UserInitializer/index.js
@@ -1,0 +1,23 @@
+const AWS = require('aws-sdk');
+const docClient = new AWS.DynamoDB.DocumentClient({
+  region: 'ap-northeast-1'
+});
+
+exports.handler = async (event) => {
+  const envName = process.env.ENV_NAME;
+  const userTableName = `neo-cycle-${envName}-USER`;
+  console.log(JSON.stringify(event))
+  const params = {
+    TableName: userTableName,
+    Item: {
+      memberId: event.userName,
+      favoriteParkingList: [],
+      settingMap: {
+        language: 'en',
+        defaultDisplay: 'map'
+      }
+    }
+  };
+  await docClient.put(params).promise();
+  return event;
+};


### PR DESCRIPTION
## やったこと
- マルチアカウント対応の一環として、ポート一覧取得APIで取得するポートのIDの取得元を、Lambdaの環境変数ではなくUserテーブルから取得するよう修正
- CognitoのLambdaトリガーを利用して、ユーザをConfirmした後にユーザレコードをDynamoにputするように修正