### PR TITLE
ログイン時にSlackに通知する

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -59,7 +59,7 @@ phases:
       - aws cloudformation deploy
           --stack-name neo-cycle-${ENVIRONMENT_NAME}-cognito-lambda
           --template-file Lambda/cognito-lambda.yaml
-          --parameter-overrides ObjectKeyPrefix=${CODEBUILD_BUILD_NUMBER} EnvName=${ENVIRONMENT_NAME}
+          --parameter-overrides ObjectKeyPrefix=${CODEBUILD_BUILD_NUMBER} EnvName=${ENVIRONMENT_NAME} SlackWebhookUrlForLoginMonitoring=${SLACK_WEBHOOK_URL_FOR_LOGIN_MONITORING}
           --capabilities CAPABILITY_AUTO_EXPAND
       - cd ..
   build:

--- a/neo-cycle-infra/CodePipeline/code-pipeline.yaml
+++ b/neo-cycle-infra/CodePipeline/code-pipeline.yaml
@@ -31,6 +31,8 @@ Parameters:
       - dev
       - prod
     Description: Enter profile.
+  SlackWebhookUrlForLoginMonitoring:
+    Type: String
 
 ######################################################
 # Resources
@@ -124,6 +126,8 @@ Resources:
             Value: !Ref EnvName
           - Name: VUE_APP_GOOGLE_API_KEY
             Value: !Ref GoogleApiKey
+          - Name: SLACK_WEBHOOK_URL_FOR_LOGIN_MONITORING
+            Value: !Ref SlackWebhookUrlForLoginMonitoring
         Type: LINUX_CONTAINER
         Image: aws/codebuild/standard:2.0-1.13.0
       ServiceRole: !GetAtt RoleCodeBuildService.Arn

--- a/neo-cycle-infra/Lambda/cognito-lambda.yaml
+++ b/neo-cycle-infra/Lambda/cognito-lambda.yaml
@@ -54,7 +54,7 @@ Resources:
       Environment:
         Variables:
           ENV_NAME: !Ref EnvName
-          SLACK_WEBHOOK_URL_FOR_LOGIN_MONITORING: !Ref SlackWebHookUrlForLoginMonitoring
+          SLACK_WEBHOOK_URL_FOR_LOGIN_MONITORING: !Ref SlackWebhookUrlForLoginMonitoring
       FunctionName: !Sub ${NameTag}-${EnvName}-UserMigrator
       Handler: index.handler
       ReservedConcurrentExecutions: 1
@@ -74,7 +74,7 @@ Resources:
       Environment:
         Variables:
           ENV_NAME: !Ref EnvName
-          SLACK_WEBHOOK_URL_FOR_LOGIN_MONITORING: !Ref SlackWebHookUrlForLoginMonitoring
+          SLACK_WEBHOOK_URL_FOR_LOGIN_MONITORING: !Ref SlackWebhookUrlForLoginMonitoring
       FunctionName: !Sub ${NameTag}-${EnvName}-PostAuthenticator
       Handler: index.handler
       ReservedConcurrentExecutions: 1

--- a/neo-cycle-infra/Lambda/cognito-lambda.yaml
+++ b/neo-cycle-infra/Lambda/cognito-lambda.yaml
@@ -20,6 +20,8 @@ Parameters:
       - dev
       - prod
     Description: Enter profile.
+  SlackWebHookUrlForLoginMonitoring:
+    Type: String
 
 ######################################################
 # Resources
@@ -52,6 +54,7 @@ Resources:
       Environment:
         Variables:
           ENV_NAME: !Ref EnvName
+          SLACK_WEBHOOK_URL_FOR_LOGIN_MONITORING: !Ref SlackWebHookUrlForLoginMonitoring
       FunctionName: !Sub ${NameTag}-${EnvName}-UserMigrator
       Handler: index.handler
       ReservedConcurrentExecutions: 1
@@ -71,6 +74,7 @@ Resources:
       Environment:
         Variables:
           ENV_NAME: !Ref EnvName
+          SLACK_WEBHOOK_URL_FOR_LOGIN_MONITORING: !Ref SlackWebHookUrlForLoginMonitoring
       FunctionName: !Sub ${NameTag}-${EnvName}-PostAuthenticator
       Handler: index.handler
       ReservedConcurrentExecutions: 1

--- a/neo-cycle-infra/Lambda/cognito-lambda.yaml
+++ b/neo-cycle-infra/Lambda/cognito-lambda.yaml
@@ -20,7 +20,7 @@ Parameters:
       - dev
       - prod
     Description: Enter profile.
-  SlackWebHookUrlForLoginMonitoring:
+  SlackWebhookUrlForLoginMonitoring:
     Type: String
 
 ######################################################

--- a/neo-cycle-lambda/PostAuthenticator/index.js
+++ b/neo-cycle-lambda/PostAuthenticator/index.js
@@ -14,6 +14,7 @@ exports.handler = async (event, context) => {
 
 async function main(event, context) {
   try {
+    if (!event.request.clientMetadata) return event
     const sessionId = await retrieveSessionId(event.userName, event.request.clientMetadata.password);
     event.response = {
       "claimsOverrideDetails": {
@@ -23,6 +24,7 @@ async function main(event, context) {
       }
     };
     console.log(`[LOGIN SUCCESS] ${event.userName}`)
+    await notifyToSlack(event.userName);
     return event;
   }
   catch (error) {
@@ -59,4 +61,16 @@ async function retrieveSessionId(memberId, password) {
   }
 }
 
+async function notifyToSlack(memberId) {
+  try {
+    const res = await axios.post(
+      process.env.SLACK_WEBHOOK_URL_FOR_LOGIN_MONITORING,
+      {
+        text: `[${new Date(Date.now() + ((new Date().getTimezoneOffset() + (9 * 60)) * 60 * 1000)).toLocaleString()}]` + '\n' + `${memberId}さんがログインしました`
+      });
+  }
+  catch (error) {
+    throw error;
+  }
+}
 


### PR DESCRIPTION
## やったこと
- CognitoトリガーLambdaの処理内でログイン成功をSlackに通知する機能を追加
   - CognitoトリガーのLambdaで、ユーザー移行成功時・セッション取得成功時にneo-cycle-dev-ログインチャンネルにログイン成功した旨をpostする
   - 環境追加時には新たなチャンネルとwebhook url生成が必要

### 不具合修正
- 初回ログイン直後の認証が完了した段階でトリガーされていたLambdaの処理が行われるが、USER_PASSWORD_AUTHで認証した場合はClientMetadataが渡されないため、セッションは確立しないように修正。