### PR TITLE
自動予約機能 - セッションを画面からテーブル参照に寄せる

### DIFF
--- a/neo-cycle-client/src/components/Login.vue
+++ b/neo-cycle-client/src/components/Login.vue
@@ -75,7 +75,9 @@ export default {
           this.openUpdatePasswordDialog()
           return
         }
-        sessionStorage.setItem('sessionId', session.getIdToken().payload.sessionId)
+        if (!!session.getIdToken().payload.sessionId) {
+          sessionStorage.setItem('sessionId', session.getIdToken().payload.sessionId)
+        }
         sessionStorage.setItem('aplVersion', session.getIdToken().payload.aplVersion)
         
         loading.close()
@@ -98,7 +100,9 @@ export default {
             this.openUpdatePasswordDialog()
             return
           }
-          sessionStorage.setItem('sessionId', session.getIdToken().payload.sessionId)
+          if (!!session.getIdToken().payload.sessionId) {
+            sessionStorage.setItem('sessionId', session.getIdToken().payload.sessionId)
+          }
           sessionStorage.setItem('aplVersion', session.getIdToken().payload.aplVersion)
           loading.close()
           this.$router.replace('/')

--- a/neo-cycle-infra/IAM/iam.yaml
+++ b/neo-cycle-infra/IAM/iam.yaml
@@ -255,6 +255,7 @@ Resources:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
         - !Ref NeoCycleUserTableGetItemPolicy
         - !Ref NeoCycleGetParameterPolicy
+        - !Ref NeoCycleSessionTableGetItemPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -276,6 +277,7 @@ Resources:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
         - !Ref NeoCycleUserTableGetItemPolicy
         - !Ref NeoCycleGetParameterPolicy
+        - !Ref NeoCycleSessionTableGetItemPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -297,6 +299,7 @@ Resources:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
         - !Ref NeoCycleUserTableGetItemPolicy
         - !Ref NeoCycleGetParameterPolicy
+        - !Ref NeoCycleSessionTableGetItemPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -402,6 +405,7 @@ Resources:
         - !FindInMap [StackConfig, ManagedPolicyArns, AWSLambdaBasicExecutionRole]
         - !Ref NeoCycleGetParameterPolicy
         - !Ref NeoCycleCommonSessionTablePutItemPolicy
+        - !Ref NeoCycleUserTableGetItemPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/neo-cycle-infra/Lambda/api-gateway-lambda.yaml
+++ b/neo-cycle-infra/Lambda/api-gateway-lambda.yaml
@@ -101,6 +101,7 @@ Resources:
         S3Key: !Sub ${ObjectKeyPrefix}/ReservationMaker/Deploy.zip
       Environment:
         Variables:
+          ENV_NAME: !Ref EnvName
           SHARE_CYCLE_API_KEY: !Ref ShareCycleApiKey
           SHARE_CYCLE_API_URL: !Ref ShareCycleApiUrl
       FunctionName: !Sub ${NameTag}-${EnvName}-ReservationMaker
@@ -120,6 +121,7 @@ Resources:
         S3Key: !Sub ${ObjectKeyPrefix}/ReservationCanceller/Deploy.zip
       Environment:
         Variables:
+          ENV_NAME: !Ref EnvName
           SHARE_CYCLE_API_KEY: !Ref ShareCycleApiKey
           SHARE_CYCLE_API_URL: !Ref ShareCycleApiUrl
       FunctionName: !Sub ${NameTag}-${EnvName}-ReservationCanceller
@@ -139,6 +141,7 @@ Resources:
         S3Key: !Sub ${ObjectKeyPrefix}/StatusChecker/Deploy.zip
       Environment:
         Variables:
+          ENV_NAME: !Ref EnvName
           SHARE_CYCLE_API_KEY: !Ref ShareCycleApiKey
           SHARE_CYCLE_API_URL: !Ref ShareCycleApiUrl
       FunctionName: !Sub ${NameTag}-${EnvName}-StatusChecker

--- a/neo-cycle-lambda/BikeAvailableRetriever/index.js
+++ b/neo-cycle-lambda/BikeAvailableRetriever/index.js
@@ -7,6 +7,7 @@ const axios = require('axios');
 const envName = process.env.ENV_NAME;
 
 const userTableName = `neo-cycle-${envName}-USER`;
+const sessionTableName = `neo-cycle-${envName}-SESSION`;
   
 exports.handler = async (event, context) => {
   if (event.warmup) {
@@ -19,7 +20,7 @@ exports.handler = async (event, context) => {
 
 async function main(event, context) {
   const memberId = JSON.parse(event.body).memberId;
-  const sessionId = JSON.parse(event.body).sessionId;
+  const sessionId = JSON.parse(event.body).sessionId ? JSON.parse(event.body).sessionId : await retrieveSessionId(memberId);
   const aplVersion = JSON.parse(event.body).aplVersion;
   const cursor = JSON.parse(event.body).cursor;
   const limit = JSON.parse(event.body).limit;
@@ -51,6 +52,17 @@ async function main(event, context) {
       isBase64Encoded: false
     };
   }
+}
+
+async function retrieveSessionId(memberId) {
+  const params = {
+    TableName: sessionTableName,
+    Key: {
+      memberId: memberId,
+    },
+  };
+  const result = await docClient.get(params).promise();
+  return result.Item.sessionId;
 }
 
 async function retrieveParkingIdList(memberId, cursor, limit) {

--- a/neo-cycle-lambda/PostAuthenticator/index.js
+++ b/neo-cycle-lambda/PostAuthenticator/index.js
@@ -21,7 +21,9 @@ async function main(event, context) {
     const sessionIdPromise = retrieveSessionId(event.userName, event.request.clientMetadata.password);
     const aplVersionPromise = retrieveApiVersion();
     const result = await Promise.all([sessionIdPromise, aplVersionPromise]);
-    await putSessionId(event.userName, result[0]);
+    if (!!result[0]) {
+      await putSessionId(event.userName, result[0]);
+    }
     event.response = {
       "claimsOverrideDetails": {
         "claimsToAddOrOverride": {
@@ -41,7 +43,7 @@ async function main(event, context) {
 
 async function retrieveSessionId(memberId, password) {
   const userInfo = await retrieveUserInfo(memberId);
-  if (userInfo.encodedPasswordBufferObj) return;
+  if (!!userInfo.encodedPasswordBufferObj) return;
   const params = {
     userID: memberId,
     password: password,
@@ -70,7 +72,7 @@ async function retrieveUserInfo(memberId) {
       memberId: memberId,
     },
   };
-  const result = await docClient.get(params);
+  const result = await docClient.get(params).promise();
   return result.Item;
 }
 

--- a/neo-cycle-lambda/PostAuthenticator/index.js
+++ b/neo-cycle-lambda/PostAuthenticator/index.js
@@ -5,6 +5,8 @@ const docClient = new AWS.DynamoDB.DocumentClient({
 
 const axios = require('axios');
 const sessionTableName = `neo-cycle-common-SESSION`;
+const envName = process.env["ENV_NAME"];
+const userTableName = `neo-cycle-${envName}-USER`;
 
 exports.handler = async (event, context) => {
   if (event.warmup) {
@@ -38,6 +40,8 @@ async function main(event, context) {
 }
 
 async function retrieveSessionId(memberId, password) {
+  const userInfo = await retrieveUserInfo(memberId);
+  if (userInfo.encodedPasswordBufferObj) return;
   const params = {
     userID: memberId,
     password: password,
@@ -57,6 +61,17 @@ async function retrieveSessionId(memberId, password) {
   catch (error) {
     throw error;
   }
+}
+
+async function retrieveUserInfo(memberId) {
+  const params = {
+    TableName: userTableName,
+    Key: {
+      memberId: memberId,
+    },
+  };
+  const result = await docClient.get(params);
+  return result.Item;
 }
 
 async function retrieveApiVersion() {

--- a/neo-cycle-lambda/ReservationCanceller/index.js
+++ b/neo-cycle-lambda/ReservationCanceller/index.js
@@ -1,6 +1,8 @@
 const AWS = require('aws-sdk');
 const axios = require('axios');
 
+const sessionTableName = `neo-cycle-${envName}-SESSION`;
+
 exports.handler = async (event, context) => {
   if (event.warmup) {
       console.log("This is warm up.");
@@ -12,7 +14,7 @@ exports.handler = async (event, context) => {
 
 async function main(event, context) {
   const memberId = JSON.parse(event.body).memberId;
-  const sessionId = JSON.parse(event.body).sessionId;
+  const sessionId = JSON.parse(event.body).sessionId ? JSON.parse(event.body).sessionId : await retrieveSessionId(memberId);
   const aplVersion = JSON.parse(event.body).aplVersion;
   try {
     await cancelReservation(memberId, sessionId, aplVersion);
@@ -37,6 +39,17 @@ async function main(event, context) {
     };
   }
   
+}
+
+async function retrieveSessionId(memberId) {
+  const params = {
+    TableName: sessionTableName,
+    Key: {
+      memberId: memberId,
+    },
+  };
+  const result = await docClient.get(params).promise();
+  return result.Item.sessionId;
 }
 
 async function cancelReservation(memberId, sessionId, aplVersion) {

--- a/neo-cycle-lambda/ReservationCanceller/index.js
+++ b/neo-cycle-lambda/ReservationCanceller/index.js
@@ -1,6 +1,8 @@
 const AWS = require('aws-sdk');
 const axios = require('axios');
 
+const envName = process.env.ENV_NAME;
+
 const sessionTableName = `neo-cycle-${envName}-SESSION`;
 
 exports.handler = async (event, context) => {

--- a/neo-cycle-lambda/ReservationCanceller/index.js
+++ b/neo-cycle-lambda/ReservationCanceller/index.js
@@ -1,4 +1,7 @@
 const AWS = require('aws-sdk');
+const docClient = new AWS.DynamoDB.DocumentClient({
+  region: 'ap-northeast-1'
+});
 const axios = require('axios');
 
 const envName = process.env.ENV_NAME;

--- a/neo-cycle-lambda/ReservationMaker/index.js
+++ b/neo-cycle-lambda/ReservationMaker/index.js
@@ -1,6 +1,8 @@
 const AWS = require('aws-sdk');
 const axios = require('axios');
 
+const envName = process.env.ENV_NAME;
+
 const sessionTableName = `neo-cycle-${envName}-SESSION`;
 
 exports.handler = async (event, context) => {

--- a/neo-cycle-lambda/ReservationMaker/index.js
+++ b/neo-cycle-lambda/ReservationMaker/index.js
@@ -1,4 +1,7 @@
 const AWS = require('aws-sdk');
+const docClient = new AWS.DynamoDB.DocumentClient({
+  region: 'ap-northeast-1'
+});
 const axios = require('axios');
 
 const envName = process.env.ENV_NAME;

--- a/neo-cycle-lambda/ReservationMaker/index.js
+++ b/neo-cycle-lambda/ReservationMaker/index.js
@@ -1,6 +1,8 @@
 const AWS = require('aws-sdk');
 const axios = require('axios');
 
+const sessionTableName = `neo-cycle-${envName}-SESSION`;
+
 exports.handler = async (event, context) => {
   if (event.warmup) {
       console.log("This is warm up.");
@@ -12,7 +14,7 @@ exports.handler = async (event, context) => {
 
 async function main(event, context) {
   const memberId = JSON.parse(event.body).memberId;
-  const sessionId = JSON.parse(event.body).sessionId;
+  const sessionId = JSON.parse(event.body).sessionId ? JSON.parse(event.body).sessionId : await retrieveSessionId(memberId);
   const aplVersion = JSON.parse(event.body).aplVersion;
   const cycleName = JSON.parse(event.body).cycleName;
   try {
@@ -48,6 +50,17 @@ async function main(event, context) {
     };
   }
   
+}
+
+async function retrieveSessionId(memberId) {
+  const params = {
+    TableName: sessionTableName,
+    Key: {
+      memberId: memberId,
+    },
+  };
+  const result = await docClient.get(params).promise();
+  return result.Item.sessionId;
 }
 
 async function makeReservation(memberId, sessionId, cycleName, aplVersion) {

--- a/neo-cycle-lambda/StatusChecker/index.js
+++ b/neo-cycle-lambda/StatusChecker/index.js
@@ -1,5 +1,7 @@
 const axios = require('axios');
 
+const sessionTableName = `neo-cycle-${envName}-SESSION`;
+
 exports.handler = async (event, context) => {
   if (event.warmup) {
       console.log("This is warm up.");
@@ -11,7 +13,7 @@ exports.handler = async (event, context) => {
 
 async function main(event, context) {
   const memberId = JSON.parse(event.body).memberId;
-  const sessionId = JSON.parse(event.body).sessionId;
+  const sessionId = JSON.parse(event.body).sessionId ? JSON.parse(event.body).sessionId : await retrieveSessionId(memberId);
   const aplVersion = JSON.parse(event.body).aplVersion;
   try {
     const response = {
@@ -68,6 +70,17 @@ async function checkStatus(sessionId, aplVersion) {
     console.log(error);
     throw error;
   }
+}
+
+async function retrieveSessionId(memberId) {
+  const params = {
+    TableName: sessionTableName,
+    Key: {
+      memberId: memberId,
+    },
+  };
+  const result = await docClient.get(params).promise();
+  return result.Item.sessionId;
 }
 
 async function getReserveCycle(sessionId, aplVersion) {

--- a/neo-cycle-lambda/StatusChecker/index.js
+++ b/neo-cycle-lambda/StatusChecker/index.js
@@ -1,3 +1,7 @@
+const AWS = require('aws-sdk');
+const docClient = new AWS.DynamoDB.DocumentClient({
+  region: 'ap-northeast-1'
+});
 const axios = require('axios');
 
 const envName = process.env.ENV_NAME;

--- a/neo-cycle-lambda/StatusChecker/index.js
+++ b/neo-cycle-lambda/StatusChecker/index.js
@@ -1,5 +1,7 @@
 const axios = require('axios');
 
+const envName = process.env.ENV_NAME;
+
 const sessionTableName = `neo-cycle-${envName}-SESSION`;
 
 exports.handler = async (event, context) => {


### PR DESCRIPTION
## やったこと
- 自動予約機能がONの場合、ログイン時にセッションIDは払い出さず、画面にも返さない。
- 各業務LambdaはセッションとしてSessionテーブルの参照結果を利用する